### PR TITLE
SPORTSHUB-162: Make move_inactive_events scheduled

### DIFF
--- a/functions/lib/move_inactive_events.py
+++ b/functions/lib/move_inactive_events.py
@@ -4,6 +4,7 @@ from firebase_admin import firestore
 from firebase_functions import https_fn, options
 from google.cloud import firestore
 from google.cloud.firestore import DocumentReference, Transaction
+from firebase_functions import scheduler_fn
 from google.protobuf.timestamp_pb2 import Timestamp
 from lib.auth import *
 from lib.constants import *
@@ -65,10 +66,8 @@ def get_and_move_private_inactive_events(today: date):
 
 
 
-@https_fn.on_request(cors=options.CorsOptions(cors_origins="*", cors_methods=["post"]))
-def move_inactive_events(req: https_fn.Request) -> https_fn.Response:
-  if (not verify_access_token_from_http_request(get_token_from_request_headers(req))):
-    return https_fn.Response(status=401)
+@scheduler_fn.on_schedule(schedule="every day 00:00")
+def move_inactive_events(event: scheduler_fn.ScheduledEvent) -> None:
   
   today = date.today()
 


### PR DESCRIPTION
the move_inactive_event cloud function now runs every day at 12am, this moves all the inactive events over to the inactive events folder, rather than keeping it in public events.