### PR TITLE
SPORTSHUB-220 fix-authentication-flow-to-work-across-two-devices

### DIFF
--- a/frontend/app/(footer)/stripe/refreshAccountLink/page.tsx
+++ b/frontend/app/(footer)/stripe/refreshAccountLink/page.tsx
@@ -2,7 +2,6 @@
 import Loading from "@/components/loading/Loading";
 import { useUser } from "@/components/utility/UserContext";
 import { EmptyUserData } from "@/interfaces/UserTypes";
-import { isLoggedIn } from "@/services/src/auth/authService";
 import { getStripeStandardAccountLink } from "@/services/src/stripe/stripeService";
 import { getRefreshAccountLinkUrl } from "@/services/src/stripe/stripeUtils";
 import { getUrlWithCurrentHostname } from "@/services/src/urlUtils";
@@ -14,7 +13,7 @@ export default function RefreshAccountLink() {
   const router = useRouter();
   useEffect(() => {
     // If user is not logged in, cannot activate RefreshAccountLink as will trigger error.
-    if (!isLoggedIn() && user === EmptyUserData) {
+    if (user !== null && user === EmptyUserData) {
       router.push("/error");
     }
     const returnUrl = getUrlWithCurrentHostname("/organiser");

--- a/frontend/services/src/auth/authService.ts
+++ b/frontend/services/src/auth/authService.ts
@@ -86,7 +86,7 @@ export async function handleEmailAndPasswordSignIn(email: string, password: stri
 
           const userData = await getTempUserData(userCredential.user.uid);
 
-          if (userData) {
+          if (userData !== null) {
             try {
               await createUser(userData, userCredential.user.uid);
               authServiceLogger.info("Temporary user data found and user created successfully.", {
@@ -134,7 +134,7 @@ export async function handleEmailAndPasswordSignIn(email: string, password: stri
     if (userCredential) {
       try {
         await signOut(auth);
-        authServiceLogger.info("User signed out due to an error.", { email });
+        authServiceLogger.info(`User signed out due to an error ${error}`, { email });
       } catch (signOutError) {
         authServiceLogger.error("Failed to sign out user during error handling.", {
           error: signOutError instanceof Error ? signOutError.message : "Unknown error",
@@ -228,15 +228,6 @@ export async function handleFacebookSignIn() {
   } catch (error) {
     console.log(error);
   }
-}
-
-/**
- * Utility function determining whether any user is logged in or not.
- * @returns boolean
- */
-export function isLoggedIn(): boolean {
-  const user = useUser();
-  return useUser() !== null;
 }
 
 const actionCodeSettings = {


### PR DESCRIPTION
**PLEASE READ**

**Problem:**
Syrio Signed In on one device and logged in on another

**Cause**
I don't think the cause of this is to do with the fact that He used two devices, the sign in and logging in should run independently of another.
I think the cause is due to the lack of atomicity in the logging in Function. 
The Logging in Code runs like this SignIn -> check if user verified -> **if not** send email again -> **if so** check if userData exists -> if user data exists then this is just normal login Proceed -> if userdata does not exists run the create user data workflow from temp data etc
So technically, the user could finish the first part of the workflow and log in, but the code stops running after hence the user is logged in but the userdata isn't populated. This could technically happen if the user closes the browser in the small time frame after the login but before the user Creation (I think this is what happened). 

So the simple solution in theory would be to just sign if after all the logging in code and make sure the logging in code is atomic

**Problem**
Problem is the logging in code requires the firebase object so we need to sign in first then run the logging in code.
2nd Problem Firebase support transactions(atomic database operations) but not cross system operations (etc firebase auth and firebase firestore), there is no easy way to make sure that a workflow containing both auth and firestore are atomic (we could with a backend but...Also can look into 3rd party things such as redis)

**Temporary Makeshift solution**
What I have done is basically if it fails at any point the code, it will automatically log you out and rollback the changes so that hopefully you can try again and succeed the next time

I have also added a lot of logging