### PR TITLE
HOTFIX - Removed EmptyPurchaser and EmptyAttendee as unnecessary and fix organiser event drilldown organiser sidebar button logic

### DIFF
--- a/frontend/components/organiser/OrganiserNavbar.tsx
+++ b/frontend/components/organiser/OrganiserNavbar.tsx
@@ -23,7 +23,7 @@ export default function OrganiserNavbar({ currPage }: OrganiserNavbarProps) {
   const { user } = useUser();
   const [eventDataList, setEventDataList] = useState<EventData[]>([EmptyEventData, EmptyEventData]);
   const [closestEvent, setClosestEvent] = useState<EventData | null>(null);
-  const [eventId, setEventId] = useState<string>("");
+  const [eventId, setEventId] = useState<string>("dashboard");
 
   useEffect(() => {
     const fetchEvents = async () => {
@@ -53,7 +53,7 @@ export default function OrganiserNavbar({ currPage }: OrganiserNavbarProps) {
 
         setEventDataList(futureEvents);
         setClosestEvent(futureEvents.length > 0 ? futureEvents[0] : null);
-        setEventId(futureEvents.length > 0 ? `organiser/event/${futureEvents[0].eventId}` : "event/create");
+        setEventId(futureEvents.length > 0 ? `${futureEvents[0].eventId}` : "dashboard");
       } catch (error) {
         console.error("getOrganiserEvents() Error: " + error);
       }
@@ -82,7 +82,7 @@ export default function OrganiserNavbar({ currPage }: OrganiserNavbarProps) {
           <CalendarIcon className="w-10 sm:w-6 stroke-1 stroke-organiser-dark-gray-text" />
         </Link>
         <Link
-          href={`/${eventId}`}
+          href={`/organiser/event/${eventId}`}
           className={`flex justify-center self-center h-12 w-12 sm:h-10 sm:w-10 sm:m-auto rounded-md hover:bg-organiser-darker-light-gray transition ease-in-out ${
             currPage === "EventDrilldown" && "bg-organiser-darker-light-gray"
           }`}

--- a/frontend/interfaces/EventTypes.ts
+++ b/frontend/interfaces/EventTypes.ts
@@ -101,17 +101,6 @@ export interface Purchaser {
   totalTicketCount: number;
 }
 
-export const EmptyAttendee: Attendee = {
-  phone: "",
-  ticketCount: 0,
-};
-
-export const EmptyPurchaser: Purchaser = {
-  email: "",
-  attendees: {},
-  totalTicketCount: 0,
-};
-
 export interface Attendee {
   phone: string;
   ticketCount: number;

--- a/frontend/services/src/events/eventsService.ts
+++ b/frontend/services/src/events/eventsService.ts
@@ -1,5 +1,4 @@
 import {
-  EmptyPurchaser,
   EventData,
   EventDataWithoutOrganiser,
   EventId,


### PR DESCRIPTION
## Why was your change needed?

Removed these 2 const exports because they were unnecessary and causing undue problems due to oversight on how TypeScript passes references.
Redid organiser sidebar button for event drilldown to not bring to error page ever

Please detail here why you did the change you did.

## What was Changed?

Please detail here what were the main changes you made.

## Any extra notes for reviewers to know?

Write any extra notes you may have for the PR.
This may include specific code paths that need extra scrutiny, or how to review a specific portion of code.
