### PR TITLE
SPORTSHUB-272 Remove Rate Limits for Update Events

### DIFF
--- a/frontend/services/src/events/eventsService.ts
+++ b/frontend/services/src/events/eventsService.ts
@@ -41,7 +41,7 @@ import {
   processEventData,
   tokenizeText,
 } from "./eventsUtils/commonEventsUtils";
-import { extractEventsMetadataFields, rateLimitCreateAndUpdateEvents } from "./eventsUtils/createEventsUtils";
+import { extractEventsMetadataFields, rateLimitCreateEvents } from "./eventsUtils/createEventsUtils";
 import {
   bustEventsLocalStorageCache,
   findEventDoc,
@@ -53,7 +53,7 @@ export const eventServiceLogger = new Logger("eventServiceLogger");
 
 //Function to create a Event
 export async function createEvent(data: NewEventData): Promise<EventId> {
-  if (!rateLimitCreateAndUpdateEvents()) {
+  if (!rateLimitCreateEvents()) {
     console.log("Rate Limited!!!");
     throw "Rate Limited";
   }
@@ -211,10 +211,6 @@ export async function getOrganiserEvents(userId: string): Promise<EventData[]> {
 }
 
 export async function updateEventById(eventId: string, updatedData: Partial<EventData>) {
-  if (!rateLimitCreateAndUpdateEvents()) {
-    eventServiceLogger.info(`Rate Limited!, ${eventId}`);
-    throw "Rate Limited";
-  }
   eventServiceLogger.info(`updateEventByName ${eventId}`);
   try {
     const eventDocRef = doc(db, "Events/Active/Public", eventId); // Get document reference by ID
@@ -291,9 +287,6 @@ export async function updateEventFromDocRef(
   updatedData: Partial<EventData>
 ): Promise<void> {
   try {
-    if (!rateLimitCreateAndUpdateEvents()) {
-      throw "Rate Limited";
-    }
     await updateDoc(eventRef, updatedData);
     eventServiceLogger.info("Event updated successfully.");
   } catch (error) {

--- a/frontend/services/src/events/eventsUtils/createEventsUtils.ts
+++ b/frontend/services/src/events/eventsUtils/createEventsUtils.ts
@@ -3,7 +3,7 @@ import { Logger } from "@/observability/logger";
 import { EVENTS_REFRESH_MILLIS, LocalStorageKeys } from "../eventsConstants";
 const rateLimitLogger = new Logger("RateLimitLogger");
 
-export function rateLimitCreateAndUpdateEvents(): boolean {
+export function rateLimitCreateEvents(): boolean {
   const now = new Date();
   const maybeOperationCount5minString = localStorage.getItem(LocalStorageKeys.OperationCount5Min);
   const maybeLastCreateUpdateOperationTimestampString = localStorage.getItem(
@@ -23,12 +23,12 @@ export function rateLimitCreateAndUpdateEvents(): boolean {
         return true;
       }
     }
-    localStorage.setItem(LocalStorageKeys.OperationCount5Min, "0");
+    localStorage.setItem(LocalStorageKeys.OperationCount5Min, "1");
     localStorage.setItem(LocalStorageKeys.LastCreateUpdateOperationTimestamp, now.toUTCString());
     return true;
   }
   // allow edit as one is null
-  localStorage.setItem(LocalStorageKeys.OperationCount5Min, "0");
+  localStorage.setItem(LocalStorageKeys.OperationCount5Min, "1");
   localStorage.setItem(LocalStorageKeys.LastCreateUpdateOperationTimestamp, now.toUTCString());
   return true;
 }


### PR DESCRIPTION
We offer alot of fields to update. From a user perspective, they would not expect to be rate limited on update events. That doesn't seem reasonable.