### PR TITLE
SPORTSHUB-169 Fix input field being covered

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -11,7 +11,7 @@
   }
 }
 @layer base {
-  .list-style-circle{
+  .list-style-circle {
     list-style: circle;
   }
 }
@@ -20,13 +20,21 @@
   @variants responsive {
     /* Hide scrollbar for Chrome, Safari and Opera */
     .no-scrollbar::-webkit-scrollbar {
-        display: none;
+      display: none;
     }
 
     /* Hide scrollbar for IE, Edge and Firefox */
     .no-scrollbar {
-        -ms-overflow-style: none;  /* IE and Edge */
-        scrollbar-width: none;  /* Firefox */
+      -ms-overflow-style: none; /* IE and Edge */
+      scrollbar-width: none; /* Firefox */
     }
   }
+}
+
+:root {
+  --navbar-height: 65px;
+}
+
+html {
+  scroll-padding-top: var(--navbar-height);
 }


### PR DESCRIPTION
## Why was your change needed?

On the create event page if the event name is not filled and next is pressed the page autoscrolls to the field but it is covered by the navbar.

Fixed by adding a css property to globals.css fairly certain it should not affect any other parts. Using 65 px as it should be slightly bigger than the true navbar height for aesthetics.
