### PR TITLE
SPORTSHUB-357 Bypass user cache when querying directly for users

### DIFF
--- a/frontend/app/(footer)/user/[id]/page.tsx
+++ b/frontend/app/(footer)/user/[id]/page.tsx
@@ -19,7 +19,7 @@ export default function UserProfilePage({ params }: any) {
   const [publicUserProfile, setPublicUserProfile] = useState<PublicUserData>(EmptyPublicUserData);
   const [upcomingOrganiserEvents, setUpcomingOrganiserEvents] = useState<EventData[]>([]);
   useEffect(() => {
-    getPublicUserById(userId).then((user) => {
+    getPublicUserById(userId, true).then((user) => {
       setPublicUserProfile(user);
 
       const fetchEvents = async () => {


### PR DESCRIPTION
for user public profile, bypass cache as it can cause undefined when its cached for too long