### PR TITLE
HOTFIX for mobile view for removing Ticket Count

### DIFF
--- a/frontend/components/events/EventBanner.tsx
+++ b/frontend/components/events/EventBanner.tsx
@@ -45,7 +45,9 @@ export default function EventBanner(props: EventBannerProps) {
                     </div>
                   </div>
                 )}
-                <p className="font-bold text-xs ml-auto md:hidden">{`${props.vacancy} Tickets Left`}</p>
+                {!props.hideVacancy && (
+                  <p className="font-bold text-xs ml-auto md:hidden">{`${props.vacancy} Tickets Left`}</p>
+                )}
               </div>
 
               <p className="text-xs hidden md:block ml-4 font-light">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vacancy count ("X Tickets Left") on mobile devices is now only displayed when appropriate, ensuring consistent behavior across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->