### PR TITLE
BUGFIX - Added a warning for refresh for unsaved forms

### DIFF
--- a/frontend/components/organiser/forms/FormEditor.tsx
+++ b/frontend/components/organiser/forms/FormEditor.tsx
@@ -57,6 +57,22 @@ const FormEditor = ({ formId }: FormEditorParams) => {
     fetchForm();
   }, [user]);
 
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (isFormModified) {
+        e.preventDefault();
+        e.returnValue = "";
+        return "";
+      }
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [isFormModified]);
+
   const handleSubmitClick = async () => {
     setIsSubmitting(true);
     if (isFormModified) {
@@ -103,15 +119,15 @@ const FormEditor = ({ formId }: FormEditorParams) => {
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const duplicateSection = (section: FormSection, sectionId: SectionId) => {
-    const newSectionId: SectionId = uuidv4() as SectionId;  // Use UUID for uniqueness
-    
+  const duplicateSection = (section: FormSection, sectionId: SectionId) => {
+    const newSectionId: SectionId = uuidv4() as SectionId; // Use UUID for uniqueness
+
     setForm((prevForm) => ({
       ...prevForm,
       sectionsOrder: [...prevForm.sectionsOrder, newSectionId],
       sectionsMap: {
         ...prevForm.sectionsMap,
-        [newSectionId]: JSON.parse(JSON.stringify(section))  // Deep clone everything
+        [newSectionId]: JSON.parse(JSON.stringify(section)), // Deep clone everything
       },
     }));
   };


### PR DESCRIPTION
## Why was your change needed?

Please detail here why you did the change you did.

## What was Changed?

Please detail here what were the main changes you made.

## Any extra notes for reviewers to know?

Write any extra notes you may have for the PR.
This may include specific code paths that need extra scrutiny, or how to review a specific portion of code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Form Editor now prevents accidental loss of work. If you have unsaved changes, attempting to close the tab, refresh, or navigate away triggers a browser confirmation prompt.
  * The prompt appears only when edits are pending; it won’t show after saving or when no changes have been made.
  * Applies to standard browser navigation actions (back/forward, reload, close).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->