### PR TITLE
NOISSUE Add pickle ball

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ At SPORTSHUB, we're not just building a platform — we're building something we
 
 ### For Players 🏃‍♂️
 
-- **Discover Events**: Find local sports events across multiple sports (volleyball, badminton, basketball, soccer, tennis, table tennis, oztag, baseball)
+- **Discover Events**: Find local sports events across multiple sports (volleyball, badminton, pickle ball, cricket, basketball, soccer, tennis, oztag, baseball)
 - **Easy Booking**: One-click booking with integrated Stripe payments
 - **Real-time Updates**: Live availability and event status
 

--- a/frontend/components/home/SearchSport.tsx
+++ b/frontend/components/home/SearchSport.tsx
@@ -17,7 +17,7 @@ export default function SearchSport() {
     Basketball: { image: BasketballImage },
     Soccer: { image: SoccerImage },
     Tennis: { image: TennisImage },
-    "Table Tennis": { image: PingPongImage },
+    "Pickle Ball": { image: PingPongImage },
     Oztag: { image: RugbyImage },
     Baseball: { image: BaseballImage },
   };

--- a/frontend/config/SportsConfig.ts
+++ b/frontend/config/SportsConfig.ts
@@ -31,6 +31,13 @@ export const SPORTS_CONFIG: Record<string, SportConfig> = {
     defaultThumbnailUrl:
       "https://firebasestorage.googleapis.com/v0/b/socialsports-44162.appspot.com/o/users%2Fgeneric%2FeventThumbnails%2Fbadminton-default.jpg?alt=media&token=187db12a-6e04-44da-aedc-04c5a1db99f7",
   },
+  "pickle-ball": {
+    name: "Pickle Ball",
+    value: "pickle-ball",
+    iconImage: TableTennisImage,
+    defaultThumbnailUrl:
+      "https://firebasestorage.googleapis.com/v0/b/socialsports-44162.appspot.com/o/users%2Fgeneric%2FeventThumbnails%2Fpickle-ball-default.jpg?alt=media&token=1233d387-1bc2-4b10-a4a6-8d20ab918337",
+  },
   cricket: {
     name: "Cricket",
     value: "cricket",
@@ -65,13 +72,6 @@ export const SPORTS_CONFIG: Record<string, SportConfig> = {
     iconImage: TennisImage,
     defaultThumbnailUrl:
       "https://firebasestorage.googleapis.com/v0/b/socialsports-44162.appspot.com/o/users%2Fgeneric%2FeventThumbnails%2Ftennis-default.jpg?alt=media&token=2dd4f5c1-30f0-4c9d-9dcf-72b40e7f14e1",
-  },
-  "table-tennis": {
-    name: "Table Tennis",
-    value: "table-tennis",
-    iconImage: TableTennisImage,
-    defaultThumbnailUrl:
-      "https://firebasestorage.googleapis.com/v0/b/socialsports-44162.appspot.com/o/users%2Fgeneric%2FeventThumbnails%2Ftable-tennis-default.jpg?alt=media&token=2a07940e-b45e-4e19-b442-d1bbe8c69a35",
   },
   oztag: {
     name: "Oztag",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Pickle Ball as a selectable sport, replacing Table Tennis across the app (icons, labels, and selection options).
  - Expanded Discover Events list to include Cricket.
  - Updated search/browse experiences to reflect the new sport lineup.

- Documentation
  - Updated README to list the current set of supported sports (including Pickle Ball and Cricket).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->