### PR TITLE
SPORTSHUB-405  small changes

### DIFF
--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -15,6 +15,9 @@ export default function Footer() {
           <Link href="/organiser/dashboard" className="mx-2">
             Organiser Hub
           </Link>
+          <Link href="/landing" className="mx-2">
+            Landing Page
+          </Link>
           <Link href="/event/create" className="mx-2">
             Create Event
           </Link>

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -16,7 +16,7 @@ export default function Footer() {
             Organiser Hub
           </Link>
           <Link href="/landing" className="mx-2">
-            Landing Page
+            Landing
           </Link>
           <Link href="/event/create" className="mx-2">
             Create Event

--- a/frontend/components/events/create/forms/PreviewForm.tsx
+++ b/frontend/components/events/create/forms/PreviewForm.tsx
@@ -57,7 +57,7 @@ export const PreviewForm = ({ form, user }: PreviewFormProps) => {
         <div className="col-span-1 mt-6 mx-2 space-y-6">
           <div>
             <div className="text-lg lg:text-lg font-bold mb-2 border-b-2 border-gray-300 text-gray-600">Sport</div>
-            <p className="text-m">{form.sport}</p>
+            <p className="text-m capitalize">{form.sport}</p>
           </div>
 
           <div>


### PR DESCRIPTION
adding landing page to footer and capitalise sport names in the create event preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Landing" link to the footer inline navigation, positioned after "Organiser Hub" and before "Create Event" for quicker access.

- **Style**
  - Capitalized the displayed sport value in the event creation preview for consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->