### PR TITLE
Make recurring event transaction

### DIFF
--- a/functions/lib/functions/src/main/java/com/functions/events/handlers/CreateEventHandler.java
+++ b/functions/lib/functions/src/main/java/com/functions/events/handlers/CreateEventHandler.java
@@ -1,15 +1,5 @@
 package com.functions.events.handlers;
 
-import static com.functions.firebase.services.FirebaseService.CollectionPaths.ACTIVE;
-import static com.functions.firebase.services.FirebaseService.CollectionPaths.EVENTS;
-import static com.functions.firebase.services.FirebaseService.CollectionPaths.EVENTS_METADATA;
-import static com.functions.firebase.services.FirebaseService.CollectionPaths.INACTIVE;
-import static com.functions.firebase.services.FirebaseService.CollectionPaths.PRIVATE;
-import static com.functions.firebase.services.FirebaseService.CollectionPaths.PUBLIC;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.functions.events.models.EventMetadata;
 import com.functions.events.models.NewEventData;
@@ -22,6 +12,10 @@ import com.functions.utils.JavaUtils;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.Transaction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.functions.firebase.services.FirebaseService.CollectionPaths.*;
 
 public class CreateEventHandler implements Handler<NewEventData, String> {
     private static final Logger logger = LoggerFactory.getLogger(CreateEventHandler.class);
@@ -75,11 +69,11 @@ public class CreateEventHandler implements Handler<NewEventData, String> {
         transaction.set(newEventDocRef, JavaUtils.toMap(data));
         final String eventId = newEventDocRef.getId();
         createEventMetadata(transaction, eventId, data);
-        EventsUtils.addEventIdToUserOrganiserEvents(data.getOrganiserId(), eventId);
+        EventsUtils.addEventIdToUserOrganiserEvents(data.getOrganiserId(), eventId, transaction);
         // If the event is public, add it to the user's public upcoming events
         if (!data.getIsPrivate()) {
             EventsUtils.addEventIdToUserOrganiserPublicUpcomingEvents(data.getOrganiserId(),
-                    newEventDocRef.getId());
+                    newEventDocRef.getId(), transaction);
         }
         return newEventDocRef.getId();
     }

--- a/functions/lib/functions/src/main/java/com/functions/events/repositories/CustomEventLinksRepository.java
+++ b/functions/lib/functions/src/main/java/com/functions/events/repositories/CustomEventLinksRepository.java
@@ -1,46 +1,47 @@
 package com.functions.events.repositories;
 
-import java.util.Collections;
-import java.util.List;
-
+import com.functions.events.models.CustomEventLink;
+import com.functions.firebase.services.FirebaseService;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.functions.events.models.CustomEventLink;
-import com.functions.firebase.services.FirebaseService;
-import com.google.cloud.firestore.Firestore;
+import java.util.Collections;
+import java.util.List;
 
 public class CustomEventLinksRepository {
-  private static final Logger logger = LoggerFactory.getLogger(CustomEventLinksRepository.class);
-  private static final Firestore db = FirebaseService.getFirestore();
+    private static final Logger logger = LoggerFactory.getLogger(CustomEventLinksRepository.class);
+    private static final Firestore db = FirebaseService.getFirestore();
 
-  public static void saveCustomEventLink(String userId, CustomEventLink customEventLink) {
-    try {
-      logger.info("Saving custom event link for user {}", userId);
-      db.collection("CustomLinks")
-          .document("Events")
-          .collection(userId)
-          .document(customEventLink.getCustomEventLink())
-          .set(customEventLink);
-    } catch (Exception e) {
-      logger.error("Error saving custom event link", e);
-      throw e;
+    public static void saveCustomEventLink(String userId, CustomEventLink customEventLink, Transaction transaction) {
+        try {
+            logger.info("Saving custom event link for user {} with transaction", userId);
+            DocumentReference docRef = db.collection("CustomLinks")
+                    .document("Events")
+                    .collection(userId)
+                    .document(customEventLink.getCustomEventLink());
+            transaction.set(docRef, customEventLink);
+        } catch (Exception e) {
+            logger.error("Error saving custom event link with transaction", e);
+            throw e;
+        }
     }
-  }
 
-  public static List<CustomEventLink> getAllEventLinksPointedToRecurrence(String userId, String recurrenceTemplateId) {
-    try {
-      logger.info("Getting all event links pointed to recurrence for user {}", userId);
-      return db
-          .collection("CustomLinks")
-          .document("Events")
-          .collection(userId)
-          .whereEqualTo("type", CustomEventLink.Type.RECURRING_EVENT.getType())
-          .whereEqualTo("referenceId", recurrenceTemplateId).get().get()
-          .toObjects(CustomEventLink.class);
-    } catch (Exception e) {
-      logger.error("Error getting all event links pointed to recurrence", e);
-      return Collections.emptyList();
+    public static List<CustomEventLink> getAllEventLinksPointedToRecurrence(String userId, String recurrenceTemplateId) {
+        try {
+            logger.info("Getting all event links pointed to recurrence for user {}", userId);
+            return db
+                    .collection("CustomLinks")
+                    .document("Events")
+                    .collection(userId)
+                    .whereEqualTo("type", CustomEventLink.Type.RECURRING_EVENT.getType())
+                    .whereEqualTo("referenceId", recurrenceTemplateId).get().get()
+                    .toObjects(CustomEventLink.class);
+        } catch (Exception e) {
+            logger.error("Error getting all event links pointed to recurrence", e);
+            return Collections.emptyList();
+        }
     }
-  }
 }

--- a/functions/lib/functions/src/main/java/com/functions/events/services/CustomEventLinksService.java
+++ b/functions/lib/functions/src/main/java/com/functions/events/services/CustomEventLinksService.java
@@ -1,35 +1,35 @@
 package com.functions.events.services;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+import com.functions.events.models.CustomEventLink;
+import com.functions.events.repositories.CustomEventLinksRepository;
+import com.google.cloud.firestore.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.functions.events.models.CustomEventLink;
-import com.functions.events.repositories.CustomEventLinksRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class CustomEventLinksService {
-  private static final Logger logger = LoggerFactory.getLogger(CustomEventLinksService.class);
+    private static final Logger logger = LoggerFactory.getLogger(CustomEventLinksService.class);
 
-  public static List<String> updateEventLinksPointedToRecurrence(String userId, String recurrenceTemplateId, String eventId) {
-    logger.info("Updating event links pointed to recurrence template {}", recurrenceTemplateId);
-    List<CustomEventLink> allReferencedEventLinks = CustomEventLinksRepository.getAllEventLinksPointedToRecurrence(userId, recurrenceTemplateId);
-    logger.info("All referenced event links: {}", allReferencedEventLinks);
-    allReferencedEventLinks.forEach(eventLink -> {
-      CustomEventLink updatedEventLink = new CustomEventLink(
-        eventLink.getCustomEventLink(),
-        eventLink.getCustomEventLinkName(),
-        eventLink.getId(),
-        eventId,
-        eventLink.getReferenceId(),
-        eventLink.getReferenceName(),
-        eventLink.getType()
-      );
-      CustomEventLinksRepository.saveCustomEventLink(userId, updatedEventLink);
-    });
-    List<String> updatedEventLinks = allReferencedEventLinks.stream().map(CustomEventLink::getCustomEventLink).collect(Collectors.toList());
-    logger.info("Updated {} event links: {}", updatedEventLinks.size(), updatedEventLinks);
-    return updatedEventLinks;
-  }
+    public static List<String> updateEventLinksPointedToRecurrence(String userId, String recurrenceTemplateId, String eventId, Transaction transaction) {
+        logger.info("Updating event links pointed to recurrence template {} with transaction", recurrenceTemplateId);
+        List<CustomEventLink> allReferencedEventLinks = CustomEventLinksRepository.getAllEventLinksPointedToRecurrence(userId, recurrenceTemplateId);
+        logger.info("All referenced event links: {}", allReferencedEventLinks);
+        allReferencedEventLinks.forEach(eventLink -> {
+            CustomEventLink updatedEventLink = new CustomEventLink(
+                    eventLink.getCustomEventLink(),
+                    eventLink.getCustomEventLinkName(),
+                    eventLink.getId(),
+                    eventId,
+                    eventLink.getReferenceId(),
+                    eventLink.getReferenceName(),
+                    eventLink.getType()
+            );
+            CustomEventLinksRepository.saveCustomEventLink(userId, updatedEventLink, transaction);
+        });
+        List<String> updatedEventLinks = allReferencedEventLinks.stream().map(CustomEventLink::getCustomEventLink).collect(Collectors.toList());
+        logger.info("Updated {} event links: {}", updatedEventLinks.size(), updatedEventLinks);
+        return updatedEventLinks;
+    }
 }

--- a/functions/lib/functions/src/main/java/com/functions/events/services/RecurringEventsCronService.java
+++ b/functions/lib/functions/src/main/java/com/functions/events/services/RecurringEventsCronService.java
@@ -1,18 +1,6 @@
 package com.functions.events.services;
 
 
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.functions.events.handlers.CreateEventHandler;
 import com.functions.events.models.NewEventData;
 import com.functions.events.models.RecurrenceData;
@@ -22,6 +10,12 @@ import com.functions.utils.JavaUtils;
 import com.functions.utils.TimeUtils;
 import com.google.cloud.Timestamp;
 import com.google.cloud.firestore.Transaction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
 
 public class RecurringEventsCronService {
     private static final Logger logger = LoggerFactory.getLogger(RecurringEventsCronService.class);
@@ -31,98 +25,100 @@ public class RecurringEventsCronService {
     }
 
     public static List<String> createEventsFromRecurrenceTemplates(LocalDate today, String targetRecurrenceTemplateId, RecurrenceTemplate targetRecurrenceTemplate, boolean createEventWorkflow) throws Exception {
+        return RecurrenceTemplateRepository.createFirestoreTransaction(transaction -> {
+            try {
+                return createEventsFromRecurrenceTemplates(today, targetRecurrenceTemplateId, targetRecurrenceTemplate, createEventWorkflow, transaction);
+            } catch (Exception e) {
+                logger.error("Error creating events from recurrence templates", e);
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public static List<String> createEventsFromRecurrenceTemplates(LocalDate today, String targetRecurrenceTemplateId, RecurrenceTemplate targetRecurrenceTemplate, boolean createEventWorkflow, Transaction transaction) throws Exception {
         logger.info("Creating events from recurrence templates. today: {}, targetRecurrenceTemplateId: {}, targetRecurrenceTemplate: {}, createEventWorkflow: {}", today, targetRecurrenceTemplateId, targetRecurrenceTemplate, createEventWorkflow);
         Map<String, RecurrenceTemplate> activeRecurrenceTemplates;
         if (targetRecurrenceTemplateId == null) {
-            activeRecurrenceTemplates = RecurrenceTemplateRepository.getAllActiveRecurrenceTemplates();
+            activeRecurrenceTemplates = RecurrenceTemplateRepository.getAllActiveRecurrenceTemplates(transaction);
         } else {
             activeRecurrenceTemplates = Map.of(targetRecurrenceTemplateId, targetRecurrenceTemplate);
         }
 
         logger.info("All Active Recurrence Templates {}", activeRecurrenceTemplates);
         List<String> moveToInactiveRecurringEvents = new ArrayList<String>();
-
         List<String> createdEventIds = new ArrayList<String>();
 
         for (Map.Entry<String, RecurrenceTemplate> recurrenceTemplateAndId : activeRecurrenceTemplates.entrySet()) {
             String recurrenceTemplateId = recurrenceTemplateAndId.getKey();
             RecurrenceTemplate recurrenceTemplate = recurrenceTemplateAndId.getValue();
 
-            // Create new transaction
-            RecurrenceTemplateRepository.createFirestoreTransaction(transaction -> {
-                if (recurrenceTemplate == null) {
-                    throw new Exception(
-                            "Could not turn recurringEventSnapshot object into RecurringEvent pojo using toObject: "
-                                    + recurrenceTemplateId);
-                }
-                NewEventData newEventData = recurrenceTemplate.getEventData();
-                RecurrenceData recurrenceData = recurrenceTemplate.getRecurrenceData();
-                Map<String, String> pastRecurrences = new HashMap<>(recurrenceData.getPastRecurrences());
+            if (recurrenceTemplate == null) {
+                throw new Exception(
+                        "Could not turn recurringEventSnapshot object into RecurringEvent pojo using toObject: "
+                                + recurrenceTemplateId);
+            }
+            NewEventData newEventData = recurrenceTemplate.getEventData();
+            RecurrenceData recurrenceData = recurrenceTemplate.getRecurrenceData();
+            Map<String, String> pastRecurrences = new HashMap<>(recurrenceData.getPastRecurrences());
 
-                boolean isStillActiveRecurrenceFlag = false;
-                List<Timestamp> allRecurrences = recurrenceData.getAllRecurrences();
+            boolean isStillActiveRecurrenceFlag = false;
+            List<Timestamp> allRecurrences = recurrenceData.getAllRecurrences();
 
-                if (createEventWorkflow) {
-                    allRecurrences = List.of(allRecurrences.get(0));
-                }
+            if (createEventWorkflow) {
+                allRecurrences = List.of(allRecurrences.get(0));
+            }
 
-                for (Timestamp recurrenceTimestamp : allRecurrences) {
-                    logger.info("Recurrence Timestamp: {}", recurrenceTimestamp);
-                    String recurrenceTimestampString = TimeUtils.getTimestampStringFromTimezone(recurrenceTimestamp, ZoneId.of("Australia/Sydney"));
-                    LocalDate eventCreationDate = TimeUtils.convertTimestampToLocalDateTime(recurrenceTimestamp).toLocalDate()
-                            .minusDays(recurrenceData.getCreateDaysBefore());
-                    logger.info("Event Creation Date: {}", eventCreationDate);
-                    if (!pastRecurrences.containsKey(recurrenceTimestampString) && (today.equals(eventCreationDate) || createEventWorkflow) && (recurrenceTemplate.getRecurrenceData().getRecurrenceEnabled())) {
-                        logger.info("Creating event for recurrence template: {} for recurrence timestamp: {}", recurrenceTemplateId, recurrenceTimestampString);
-                        NewEventData newEventDataDeepCopy = JavaUtils.deepCopy(newEventData, NewEventData.class);
-                        long eventLengthMillis = newEventDataDeepCopy.getEndDate().toSqlTimestamp().getTime() - newEventDataDeepCopy.getStartDate().toSqlTimestamp().getTime();
-                        long eventDeadlineDeltaMillis = newEventDataDeepCopy.getRegistrationDeadline().toSqlTimestamp().getTime() - newEventDataDeepCopy.getStartDate().toSqlTimestamp().getTime();
-                        newEventDataDeepCopy.setStartDate(recurrenceTimestamp);
-                        Timestamp newEndDate = Timestamp.ofTimeMicroseconds((recurrenceTimestamp.toSqlTimestamp().getTime() + eventLengthMillis) * 1000);
-                        Timestamp newRegistrationDeadline = Timestamp.ofTimeMicroseconds((recurrenceTimestamp.toSqlTimestamp().getTime() + eventDeadlineDeltaMillis) * 1000);
-                        newEventDataDeepCopy.setEndDate(newEndDate);
-                        newEventDataDeepCopy.setRegistrationDeadline(newRegistrationDeadline);
-                        String newEventId = CreateEventHandler.createEvent(newEventDataDeepCopy, transaction);
-                        logger.info("New event id: {}", newEventId);
-                        createdEventIds.add(newEventId);
-                        pastRecurrences.put(recurrenceTimestampString, newEventId);
+            for (Timestamp recurrenceTimestamp : allRecurrences) {
+                logger.info("Recurrence Timestamp: {}", recurrenceTimestamp);
+                String recurrenceTimestampString = TimeUtils.getTimestampStringFromTimezone(recurrenceTimestamp, ZoneId.of("Australia/Sydney"));
+                LocalDate eventCreationDate = TimeUtils.convertTimestampToLocalDateTime(recurrenceTimestamp).toLocalDate()
+                        .minusDays(recurrenceData.getCreateDaysBefore());
+                logger.info("Event Creation Date: {}", eventCreationDate);
+                if (!pastRecurrences.containsKey(recurrenceTimestampString) && (today.equals(eventCreationDate) || createEventWorkflow) && (recurrenceTemplate.getRecurrenceData().getRecurrenceEnabled())) {
+                    logger.info("Creating event for recurrence template: {} for recurrence timestamp: {}", recurrenceTemplateId, recurrenceTimestampString);
+                    NewEventData newEventDataDeepCopy = JavaUtils.deepCopy(newEventData, NewEventData.class);
+                    long eventLengthMillis = newEventDataDeepCopy.getEndDate().toSqlTimestamp().getTime() - newEventDataDeepCopy.getStartDate().toSqlTimestamp().getTime();
+                    long eventDeadlineDeltaMillis = newEventDataDeepCopy.getRegistrationDeadline().toSqlTimestamp().getTime() - newEventDataDeepCopy.getStartDate().toSqlTimestamp().getTime();
+                    newEventDataDeepCopy.setStartDate(recurrenceTimestamp);
+                    Timestamp newEndDate = Timestamp.ofTimeMicroseconds((recurrenceTimestamp.toSqlTimestamp().getTime() + eventLengthMillis) * 1000);
+                    Timestamp newRegistrationDeadline = Timestamp.ofTimeMicroseconds((recurrenceTimestamp.toSqlTimestamp().getTime() + eventDeadlineDeltaMillis) * 1000);
+                    newEventDataDeepCopy.setEndDate(newEndDate);
+                    newEventDataDeepCopy.setRegistrationDeadline(newRegistrationDeadline);
+                    String newEventId = CreateEventHandler.createEvent(newEventDataDeepCopy, transaction);
+                    logger.info("New event id: {}", newEventId);
+                    createdEventIds.add(newEventId);
+                    pastRecurrences.put(recurrenceTimestampString, newEventId);
 
-                        // Update custom event links references
-                        try {
-                            CustomEventLinksService.updateEventLinksPointedToRecurrence(newEventDataDeepCopy.getOrganiserId(), recurrenceTemplateId, newEventId);
-                        } catch (Exception e) {
-                            logger.error("Failed to update custom event links for recurrence template {}: {}", recurrenceTemplateId, e.getMessage());
-                            // Continue with event creation even if custom links update fails
-                        }
-                    }
-
-                    if (!recurrenceData.getAllRecurrences().isEmpty()) {
-                        Timestamp latestTimestamp = Collections.max(recurrenceData.getAllRecurrences(), Timestamp::compareTo);
-                        LocalDate finalEventCreationDate = TimeUtils.convertTimestampToLocalDateTime(latestTimestamp).toLocalDate().minusDays(recurrenceData.getCreateDaysBefore());
-                        if (today.isBefore(finalEventCreationDate)) {
-                            isStillActiveRecurrenceFlag = true;
-                        }
+                    // Update custom event links references
+                    try {
+                        CustomEventLinksService.updateEventLinksPointedToRecurrence(newEventDataDeepCopy.getOrganiserId(), recurrenceTemplateId, newEventId, transaction);
+                    } catch (Exception e) {
+                        logger.error("Failed to update custom event links for recurrence template {}: {}", recurrenceTemplateId, e.getMessage());
+                        // Continue with event creation even if custom links update fails
                     }
                 }
-                RecurrenceData newRecurrenceData = recurrenceData.toBuilder().pastRecurrences(pastRecurrences).build();
-                logger.info("New Recurrence Data {}", newRecurrenceData.getPastRecurrences());
-                RecurrenceTemplate newRecurrenceTemplate = recurrenceTemplate.toBuilder().recurrenceData(newRecurrenceData).build();
 
-                RecurrenceTemplateRepository.updateRecurrenceTemplate(recurrenceTemplateId, newRecurrenceTemplate, transaction);
-
-                if (!isStillActiveRecurrenceFlag) {
-                    moveToInactiveRecurringEvents.add(recurrenceTemplateId);
+                if (!recurrenceData.getAllRecurrences().isEmpty()) {
+                    Timestamp latestTimestamp = Collections.max(recurrenceData.getAllRecurrences(), Timestamp::compareTo);
+                    LocalDate finalEventCreationDate = TimeUtils.convertTimestampToLocalDateTime(latestTimestamp).toLocalDate().minusDays(recurrenceData.getCreateDaysBefore());
+                    if (today.isBefore(finalEventCreationDate)) {
+                        isStillActiveRecurrenceFlag = true;
+                    }
                 }
-                return true;
-            });
+            }
+            RecurrenceData newRecurrenceData = recurrenceData.toBuilder().pastRecurrences(pastRecurrences).build();
+            logger.info("New Recurrence Data {}", newRecurrenceData.getPastRecurrences());
+            RecurrenceTemplate newRecurrenceTemplate = recurrenceTemplate.toBuilder().recurrenceData(newRecurrenceData).build();
+
+            RecurrenceTemplateRepository.updateRecurrenceTemplate(recurrenceTemplateId, newRecurrenceTemplate, transaction);
+
+            if (!isStillActiveRecurrenceFlag) {
+                moveToInactiveRecurringEvents.add(recurrenceTemplateId);
+            }
         }
 
-        for (
-                String recurringEventId : moveToInactiveRecurringEvents) {
-            RecurrenceTemplateRepository.createFirestoreTransaction(transaction -> {
-                moveRecurringEventToInactive(recurringEventId, transaction);
-                return null;
-            });
+        for (String recurringEventId : moveToInactiveRecurringEvents) {
+            moveRecurringEventToInactive(recurringEventId, transaction);
         }
 
         return createdEventIds;

--- a/functions/lib/functions/src/main/java/com/functions/events/utils/EventsUtils.java
+++ b/functions/lib/functions/src/main/java/com/functions/events/utils/EventsUtils.java
@@ -3,7 +3,7 @@ package com.functions.events.utils;
 import com.functions.users.models.PrivateUserData;
 import com.functions.users.models.PublicUserData;
 import com.functions.users.services.Users;
-
+import com.google.cloud.firestore.Transaction;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,26 +14,26 @@ public class EventsUtils {
                 .collect(Collectors.toList());
     }
 
-    public static void addEventIdToUserOrganiserPublicUpcomingEvents(String userId, String eventId)
+    public static void addEventIdToUserOrganiserPublicUpcomingEvents(String userId, String eventId, Transaction transaction)
             throws Exception {
-        PublicUserData publicUserData = Users.getPublicUserDataById(userId);
+        PublicUserData publicUserData = Users.getPublicUserDataById(userId, transaction);
 
         List<String> publicUpcomingOrganiserEvents =
                 publicUserData.getPublicUpcomingOrganiserEvents();
         publicUpcomingOrganiserEvents.add(eventId);
         publicUserData.setPublicUpcomingOrganiserEvents(publicUpcomingOrganiserEvents);
 
-        Users.updatePublicUserData(userId, publicUserData);
+        Users.updatePublicUserData(userId, publicUserData, transaction);
     }
 
-    public static void addEventIdToUserOrganiserEvents(String userId, String eventId)
+    public static void addEventIdToUserOrganiserEvents(String userId, String eventId, Transaction transaction)
             throws Exception {
-        PrivateUserData privateUserData = Users.getPrivateUserDataById(userId);
+        PrivateUserData privateUserData = Users.getPrivateUserDataById(userId, transaction);
 
         List<String> organiserEvents = privateUserData.getOrganiserEvents();
         organiserEvents.add(eventId);
         privateUserData.setOrganiserEvents(organiserEvents);
 
-        Users.updatePrivateUserData(userId, privateUserData);
+        Users.updatePrivateUserData(userId, privateUserData, transaction);
     }
 }

--- a/functions/lib/functions/src/main/java/com/functions/users/services/Users.java
+++ b/functions/lib/functions/src/main/java/com/functions/users/services/Users.java
@@ -1,54 +1,70 @@
 package com.functions.users.services;
 
+import com.functions.firebase.services.FirebaseService;
+import com.functions.firebase.services.FirebaseService.CollectionPaths;
 import com.functions.users.models.PrivateUserData;
 import com.functions.users.models.PublicUserData;
 import com.functions.users.models.UserData;
 import com.functions.users.utils.UsersUtils;
+import com.functions.utils.JavaUtils;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.Firestore;
-import com.functions.firebase.services.FirebaseService;
-import com.functions.utils.JavaUtils;
-import com.functions.firebase.services.FirebaseService.CollectionPaths;
+import com.google.cloud.firestore.Transaction;
 
 public class Users {
 
-	public static void updateUser(String userId, UserData newData) {
-		Firestore db = FirebaseService.getFirestore();
-		DocumentReference publicUserInfoDocRef = db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE)
-				.collection(CollectionPaths.PUBLIC).document(userId);
-		DocumentReference privateUserInfoDocRef = db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE)
-				.collection(CollectionPaths.PRIVATE).document(userId);
+    public static void updateUser(String userId, UserData newData) {
+        Firestore db = FirebaseService.getFirestore();
+        DocumentReference publicUserInfoDocRef = db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE)
+                .collection(CollectionPaths.PUBLIC).document(userId);
+        DocumentReference privateUserInfoDocRef = db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE)
+                .collection(CollectionPaths.PRIVATE).document(userId);
 
-		PublicUserData publicUserData = UsersUtils.extractPublicUserData(newData);
-		publicUserInfoDocRef.update(JavaUtils.toMap(publicUserData));
+        PublicUserData publicUserData = UsersUtils.extractPublicUserData(newData);
+        publicUserInfoDocRef.update(JavaUtils.toMap(publicUserData));
 
-		PrivateUserData privateUserData = UsersUtils.extracPrivateUserData(newData);
-		privateUserInfoDocRef.update(JavaUtils.toMap(privateUserData));
-	}
+        PrivateUserData privateUserData = UsersUtils.extracPrivateUserData(newData);
+        privateUserInfoDocRef.update(JavaUtils.toMap(privateUserData));
+    }
 
-	public static void updatePublicUserData(String userId, PublicUserData newData) {
-		Firestore db = FirebaseService.getFirestore();
-		db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE).collection(CollectionPaths.PUBLIC)
-				.document(userId).update(JavaUtils.toMap(newData));
-	}
+    public static void updatePublicUserData(String userId, PublicUserData newData, Transaction transaction) {
+        Firestore db = FirebaseService.getFirestore();
+        DocumentReference docRef = db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE)
+                .collection(CollectionPaths.PUBLIC).document(userId);
+        transaction.update(docRef, JavaUtils.toMap(newData));
+    }
 
-	public static void updatePrivateUserData(String userId, PrivateUserData newData) {
-		Firestore db = FirebaseService.getFirestore();
-		db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE).collection(CollectionPaths.PRIVATE)
-				.document(userId).update(JavaUtils.toMap(newData));
-	}
-	
-	public static PublicUserData getPublicUserDataById(String userId) throws Exception {
-		Firestore db = FirebaseService.getFirestore();
-		DocumentReference docRef = db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE)
-				.collection(CollectionPaths.PUBLIC).document(userId);
-        return docRef.get().get().toObject(PublicUserData.class);
-	}
+    public static void updatePrivateUserData(String userId, PrivateUserData newData) {
+        Firestore db = FirebaseService.getFirestore();
+        db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE).collection(CollectionPaths.PRIVATE)
+                .document(userId).update(JavaUtils.toMap(newData));
+    }
 
-	public static PrivateUserData getPrivateUserDataById(String userId) throws Exception {
-		Firestore db = FirebaseService.getFirestore();
-		DocumentReference docRef = db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE)
-				.collection(CollectionPaths.PRIVATE).document(userId);
+    public static void updatePrivateUserData(String userId, PrivateUserData newData, Transaction transaction) {
+        Firestore db = FirebaseService.getFirestore();
+        DocumentReference docRef = db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE)
+                .collection(CollectionPaths.PRIVATE).document(userId);
+        transaction.update(docRef, JavaUtils.toMap(newData));
+    }
+
+    public static PublicUserData getPublicUserDataById(String userId, Transaction transaction) throws Exception {
+        Firestore db = FirebaseService.getFirestore();
+        DocumentReference docRef = db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE)
+                .collection(CollectionPaths.PUBLIC).document(userId);
+        return transaction.get(docRef).get().toObject(PublicUserData.class);
+    }
+
+    public static PrivateUserData getPrivateUserDataById(String userId) throws Exception {
+        Firestore db = FirebaseService.getFirestore();
+        DocumentReference docRef = db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE)
+                .collection(CollectionPaths.PRIVATE).document(userId);
         return docRef.get().get().toObject(PrivateUserData.class);
-	}
+    }
+
+    public static PrivateUserData getPrivateUserDataById(String userId, Transaction transaction) throws Exception {
+        Firestore db = FirebaseService.getFirestore();
+        DocumentReference docRef = db.collection(CollectionPaths.USERS).document(CollectionPaths.ACTIVE)
+                .collection(CollectionPaths.PRIVATE).document(userId);
+        return transaction.get(docRef).get().toObject(PrivateUserData.class);
+    }
 }


### PR DESCRIPTION
We ran into situation where duplicate recurring events were created from the recurring events cron because of the presence of 2 schedulers running at the same time. This should not happen in the first place and should be prevented by using a transaction.