### PR TITLE
HOTFIX Point recurrence card to right link

### DIFF
--- a/frontend/components/organiser/recurring-events/RecurringTemplateCard.tsx
+++ b/frontend/components/organiser/recurring-events/RecurringTemplateCard.tsx
@@ -32,7 +32,7 @@ export default function RecurringTemplateCard(props: RecurringTemplateCardProps)
   }
 
   return (
-    <Link href={`/organiser/recurring-events/${props.recurrenceTemplateId}`}>
+    <Link href={`/organiser/event/recurring-events/${props.recurrenceTemplateId}`}>
       <div className="bg-white rounded-lg text-left border-gray-300 border w-full hover:cursor-pointer">
         {props.loading ? (
           <div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation from Recurring Template cards to direct to the correct organiser/event/recurring-events/{id} route, replacing the previous path. This resolves incorrect routing that could lead to missing pages or errors when opening a template. No changes to visuals or other interactions; users can continue browsing templates as before, with links now reliably opening the intended details screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->