### PR TITLE
Configure Max tickets on checkout

### DIFF
--- a/frontend/app/(footer)/event/create/page.tsx
+++ b/frontend/app/(footer)/event/create/page.tsx
@@ -10,12 +10,13 @@ import { useMultistepForm } from "@/components/events/create/forms/useMultistepF
 import Loading from "@/components/loading/Loading";
 import { useUser } from "@/components/utility/UserContext";
 import { SPORTS_CONFIG } from "@/config/SportsConfig";
-import { EventId, NewEventData } from "@/interfaces/EventTypes";
+import { DEFAULT_MAX_TICKETS_PER_ORDER, EventId, NewEventData } from "@/interfaces/EventTypes";
 import { FormId } from "@/interfaces/FormTypes";
 import { DEFAULT_RECURRENCE_FORM_DATA, NewRecurrenceFormData } from "@/interfaces/RecurringEventTypes";
 import { UserData } from "@/interfaces/UserTypes";
 import { Logger } from "@/observability/logger";
 import { createEvent } from "@/services/src/events/eventsService";
+import { clampMaxTicketsPerTransaction } from "@/services/src/events/eventsUtils/ticketLimits";
 import {
   getImageAndThumbnailUrlsWithDefaults,
   getUsersEventImagesUrls,
@@ -93,7 +94,7 @@ const INITIAL_DATA: FormData = {
   waitlistEnabled: true,
   bookingApprovalEnabled: false,
   showAttendeesOnEventPage: false,
-  maxTicketsPerTransaction: 10,
+  maxTicketsPerTransaction: DEFAULT_MAX_TICKETS_PER_ORDER,
 };
 
 export default function CreateEvent() {
@@ -279,7 +280,10 @@ export default function CreateEvent() {
       bookingApprovalEnabled: formData.bookingApprovalEnabled,
       formId: formData.formId,
       showAttendeesOnEventPage: formData.showAttendeesOnEventPage,
-      maxTicketsPerTransaction: Math.min(10, formData.capacity, formData.maxTicketsPerTransaction),
+      maxTicketsPerTransaction: clampMaxTicketsPerTransaction(
+        formData.maxTicketsPerTransaction,
+        formData.capacity
+      ),
     };
   }
 

--- a/frontend/app/(footer)/event/create/page.tsx
+++ b/frontend/app/(footer)/event/create/page.tsx
@@ -60,6 +60,7 @@ export type FormData = {
   waitlistEnabled: boolean;
   bookingApprovalEnabled: boolean;
   showAttendeesOnEventPage: boolean;
+  maxTicketsPerTransaction: number;
 };
 
 const INITIAL_DATA: FormData = {
@@ -92,6 +93,7 @@ const INITIAL_DATA: FormData = {
   waitlistEnabled: true,
   bookingApprovalEnabled: false,
   showAttendeesOnEventPage: false,
+  maxTicketsPerTransaction: 10,
 };
 
 export default function CreateEvent() {
@@ -277,6 +279,7 @@ export default function CreateEvent() {
       bookingApprovalEnabled: formData.bookingApprovalEnabled,
       formId: formData.formId,
       showAttendeesOnEventPage: formData.showAttendeesOnEventPage,
+      maxTicketsPerTransaction: Math.min(10, formData.capacity, formData.maxTicketsPerTransaction),
     };
   }
 

--- a/frontend/app/(no-footer)/organiser/event/[id]/page.tsx
+++ b/frontend/app/(no-footer)/organiser/event/[id]/page.tsx
@@ -19,8 +19,7 @@ import {
   EventData,
   EventId,
   EventMetadata,
-  MAX_TICKETS_PER_ORDER,
-  MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP,
+  DEFAULT_MAX_TICKETS_PER_ORDER,
 } from "@/interfaces/EventTypes";
 import { FormId } from "@/interfaces/FormTypes";
 import { Order } from "@/interfaces/OrderTypes";
@@ -29,6 +28,7 @@ import { EmptyPublicUserData, PublicUserData } from "@/interfaces/UserTypes";
 import { getEventsMetadataByEventId } from "@/services/src/events/eventsMetadata/eventsMetadataService";
 import { eventServiceLogger, getEventById, updateEventById } from "@/services/src/events/eventsService";
 import { bustEventsLocalStorageCache } from "@/services/src/events/eventsUtils/getEventsUtils";
+import { clampMaxTicketsPerTransaction } from "@/services/src/events/eventsUtils/ticketLimits";
 import { getOrdersByIds } from "@/services/src/tickets/orderService";
 import { getTicketsByIds } from "@/services/src/tickets/ticketService";
 import { calculateNetSales } from "@/services/src/tickets/ticketUtils/ticketUtils";
@@ -71,7 +71,7 @@ export default function EventPage({ params }: EventPageProps) {
   const [eventWaitlistEnabled, setEventWaitlistEnabled] = useState<boolean>(true);
   const [eventBookingApprovalEnabled, setEventBookingApprovalEnabled] = useState<boolean>(false);
   const [eventShowAttendeesOnEventPage, setEventShowAttendeesOnEventPage] = useState<boolean>(false);
-  const [eventMaxTicketsPerTransaction, setEventMaxTicketsPerTransaction] = useState<number>(MAX_TICKETS_PER_ORDER);
+  const [eventMaxTicketsPerTransaction, setEventMaxTicketsPerTransaction] = useState<number>(DEFAULT_MAX_TICKETS_PER_ORDER);
   const [eventIsActive, setEventIsActive] = useState<boolean>(false);
   const [eventFormId, setEventFormId] = useState<FormId | null>(null);
   const [totalNetSales, setTotalNetSales] = useState<number>(0);
@@ -125,14 +125,9 @@ export default function EventPage({ params }: EventPageProps) {
         setEventWaitlistEnabled(event.waitlistEnabled);
         setEventBookingApprovalEnabled(event.bookingApprovalEnabled);
         setEventShowAttendeesOnEventPage(event.showAttendeesOnEventPage);
-        {
-          const maxAllowed = Math.max(
-            1,
-            Math.min(event.capacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP)
-          );
-          const raw = event.maxTicketsPerTransaction ?? MAX_TICKETS_PER_ORDER;
-          setEventMaxTicketsPerTransaction(Math.min(maxAllowed, Math.max(1, raw)));
-        }
+        setEventMaxTicketsPerTransaction(
+          clampMaxTicketsPerTransaction(event.maxTicketsPerTransaction ?? DEFAULT_MAX_TICKETS_PER_ORDER, event.capacity)
+        );
 
         const nextEventMetadata = await getEventsMetadataByEventId(eventId);
         if (!isActive) {

--- a/frontend/app/(no-footer)/organiser/event/[id]/page.tsx
+++ b/frontend/app/(no-footer)/organiser/event/[id]/page.tsx
@@ -13,7 +13,15 @@ import { EventDrilldownImagesPage } from "@/components/organiser/event/images/Ev
 import EventDrilldownSettingsPage from "@/components/organiser/event/settings/EventDrilldownSettingsPage";
 import { MobileEventDrilldownNavTabs } from "@/components/organiser/mobile/MobileEventDrilldownNavTabs";
 import { useUser } from "@/components/utility/UserContext";
-import { EmptyEventData, EmptyEventMetadata, EventData, EventId, EventMetadata } from "@/interfaces/EventTypes";
+import {
+  EmptyEventData,
+  EmptyEventMetadata,
+  EventData,
+  EventId,
+  EventMetadata,
+  MAX_TICKETS_PER_ORDER,
+  MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP,
+} from "@/interfaces/EventTypes";
 import { FormId } from "@/interfaces/FormTypes";
 import { Order } from "@/interfaces/OrderTypes";
 import { Ticket } from "@/interfaces/TicketTypes";
@@ -63,6 +71,7 @@ export default function EventPage({ params }: EventPageProps) {
   const [eventWaitlistEnabled, setEventWaitlistEnabled] = useState<boolean>(true);
   const [eventBookingApprovalEnabled, setEventBookingApprovalEnabled] = useState<boolean>(false);
   const [eventShowAttendeesOnEventPage, setEventShowAttendeesOnEventPage] = useState<boolean>(false);
+  const [eventMaxTicketsPerTransaction, setEventMaxTicketsPerTransaction] = useState<number>(MAX_TICKETS_PER_ORDER);
   const [eventIsActive, setEventIsActive] = useState<boolean>(false);
   const [eventFormId, setEventFormId] = useState<FormId | null>(null);
   const [totalNetSales, setTotalNetSales] = useState<number>(0);
@@ -116,6 +125,14 @@ export default function EventPage({ params }: EventPageProps) {
         setEventWaitlistEnabled(event.waitlistEnabled);
         setEventBookingApprovalEnabled(event.bookingApprovalEnabled);
         setEventShowAttendeesOnEventPage(event.showAttendeesOnEventPage);
+        {
+          const maxAllowed = Math.max(
+            1,
+            Math.min(event.capacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP)
+          );
+          const raw = event.maxTicketsPerTransaction ?? MAX_TICKETS_PER_ORDER;
+          setEventMaxTicketsPerTransaction(Math.min(maxAllowed, Math.max(1, raw)));
+        }
 
         const nextEventMetadata = await getEventsMetadataByEventId(eventId);
         if (!isActive) {
@@ -279,6 +296,9 @@ export default function EventPage({ params }: EventPageProps) {
                 setBookingApprovalEnabled={setEventBookingApprovalEnabled}
                 showAttendeesOnEventPage={eventShowAttendeesOnEventPage}
                 setShowAttendeesOnEventPage={setEventShowAttendeesOnEventPage}
+                maxTicketsPerTransaction={eventMaxTicketsPerTransaction}
+                setMaxTicketsPerTransaction={setEventMaxTicketsPerTransaction}
+                eventCapacity={eventCapacity}
               />
             )}
             {currSidebarPage === "Communication" && <EventDrilldownCommunicationPage />}

--- a/frontend/app/(no-footer)/organiser/event/recurring-events/[id]/page.tsx
+++ b/frontend/app/(no-footer)/organiser/event/recurring-events/[id]/page.tsx
@@ -8,7 +8,12 @@ import RecurringTemplateDrilldownSettings from "@/components/organiser/recurring
 import RecurringTemplateDrilldownSidePanel from "@/components/organiser/recurring-events/RecurringTemplateDrilldownSidePanel";
 import { RecurringTemplatePastEvents } from "@/components/organiser/recurring-events/RecurringTemplatePastEvents";
 import { RecurringTemplateSettings } from "@/components/organiser/recurring-events/RecurringTemplateSettings";
-import { EventId, NewEventData } from "@/interfaces/EventTypes";
+import {
+  EventId,
+  MAX_TICKETS_PER_ORDER,
+  MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP,
+  NewEventData,
+} from "@/interfaces/EventTypes";
 import { FormId } from "@/interfaces/FormTypes";
 import {
   DEFAULT_RECURRENCE_FORM_DATA,
@@ -67,6 +72,7 @@ export default function RecurrenceTemplatePage({ params }: RecurrenceTemplatePag
   const [eventWaitlistEnabled, setEventWaitlistEnabled] = useState<boolean>(true);
   const [eventBookingApprovalEnabled, setEventBookingApprovalEnabled] = useState<boolean>(false);
   const [eventShowAttendeesOnEventPage, setEventShowAttendeesOnEventPage] = useState<boolean>(false);
+  const [eventMaxTicketsPerTransaction, setEventMaxTicketsPerTransaction] = useState<number>(MAX_TICKETS_PER_ORDER);
   const [pastEvents, setPastEvents] = useState<Record<number, EventId>>({});
   const [recurrenceEnded, setRecurrenceEnded] = useState<boolean>(false);
   const [eventFormId, setEventFormId] = useState<FormId | null>(null);
@@ -114,6 +120,14 @@ export default function RecurrenceTemplatePage({ params }: RecurrenceTemplatePag
         setEventWaitlistEnabled(recurrenceTemplate.eventData.waitlistEnabled);
         setEventBookingApprovalEnabled(recurrenceTemplate.eventData.bookingApprovalEnabled);
         setEventShowAttendeesOnEventPage(recurrenceTemplate.eventData.showAttendeesOnEventPage);
+        {
+          const maxAllowed = Math.max(
+            1,
+            Math.min(recurrenceTemplate.eventData.capacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP)
+          );
+          const raw = recurrenceTemplate.eventData.maxTicketsPerTransaction ?? MAX_TICKETS_PER_ORDER;
+          setEventMaxTicketsPerTransaction(Math.min(maxAllowed, Math.max(1, raw)));
+        }
         const isRecurrenceEnded = calculateRecurrenceEnded(recurrenceTemplate);
         setRecurrenceEnded(isRecurrenceEnded);
         // Edge case, if the recurrence is ended, it should not be enabled
@@ -252,6 +266,9 @@ export default function RecurrenceTemplatePage({ params }: RecurrenceTemplatePag
                   setBookingApprovalEnabled={setEventBookingApprovalEnabled}
                   showAttendeesOnEventPage={eventShowAttendeesOnEventPage}
                   setShowAttendeesOnEventPage={setEventShowAttendeesOnEventPage}
+                  maxTicketsPerTransaction={eventMaxTicketsPerTransaction}
+                  setMaxTicketsPerTransaction={setEventMaxTicketsPerTransaction}
+                  eventCapacity={eventCapacity}
                 />
               </>
             )}

--- a/frontend/app/(no-footer)/organiser/event/recurring-events/[id]/page.tsx
+++ b/frontend/app/(no-footer)/organiser/event/recurring-events/[id]/page.tsx
@@ -9,9 +9,8 @@ import RecurringTemplateDrilldownSidePanel from "@/components/organiser/recurrin
 import { RecurringTemplatePastEvents } from "@/components/organiser/recurring-events/RecurringTemplatePastEvents";
 import { RecurringTemplateSettings } from "@/components/organiser/recurring-events/RecurringTemplateSettings";
 import {
+  DEFAULT_MAX_TICKETS_PER_ORDER,
   EventId,
-  MAX_TICKETS_PER_ORDER,
-  MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP,
   NewEventData,
 } from "@/interfaces/EventTypes";
 import { FormId } from "@/interfaces/FormTypes";
@@ -29,6 +28,7 @@ import {
   updateRecurrenceTemplateEventData,
   updateRecurrenceTemplateRecurrenceData,
 } from "@/services/src/recurringEvents/recurringEventsService";
+import { clampMaxTicketsPerTransaction } from "@/services/src/events/eventsUtils/ticketLimits";
 import { extractNewRecurrenceFormDataFromRecurrenceData } from "@/services/src/recurringEvents/recurringEventsUtils";
 import { sleep } from "@/utilities/sleepUtil";
 import { Alert } from "@material-tailwind/react";
@@ -72,7 +72,7 @@ export default function RecurrenceTemplatePage({ params }: RecurrenceTemplatePag
   const [eventWaitlistEnabled, setEventWaitlistEnabled] = useState<boolean>(true);
   const [eventBookingApprovalEnabled, setEventBookingApprovalEnabled] = useState<boolean>(false);
   const [eventShowAttendeesOnEventPage, setEventShowAttendeesOnEventPage] = useState<boolean>(false);
-  const [eventMaxTicketsPerTransaction, setEventMaxTicketsPerTransaction] = useState<number>(MAX_TICKETS_PER_ORDER);
+  const [eventMaxTicketsPerTransaction, setEventMaxTicketsPerTransaction] = useState<number>(DEFAULT_MAX_TICKETS_PER_ORDER);
   const [pastEvents, setPastEvents] = useState<Record<number, EventId>>({});
   const [recurrenceEnded, setRecurrenceEnded] = useState<boolean>(false);
   const [eventFormId, setEventFormId] = useState<FormId | null>(null);
@@ -120,14 +120,12 @@ export default function RecurrenceTemplatePage({ params }: RecurrenceTemplatePag
         setEventWaitlistEnabled(recurrenceTemplate.eventData.waitlistEnabled);
         setEventBookingApprovalEnabled(recurrenceTemplate.eventData.bookingApprovalEnabled);
         setEventShowAttendeesOnEventPage(recurrenceTemplate.eventData.showAttendeesOnEventPage);
-        {
-          const maxAllowed = Math.max(
-            1,
-            Math.min(recurrenceTemplate.eventData.capacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP)
-          );
-          const raw = recurrenceTemplate.eventData.maxTicketsPerTransaction ?? MAX_TICKETS_PER_ORDER;
-          setEventMaxTicketsPerTransaction(Math.min(maxAllowed, Math.max(1, raw)));
-        }
+        setEventMaxTicketsPerTransaction(
+          clampMaxTicketsPerTransaction(
+            recurrenceTemplate.eventData.maxTicketsPerTransaction ?? DEFAULT_MAX_TICKETS_PER_ORDER,
+            recurrenceTemplate.eventData.capacity
+          )
+        );
         const isRecurrenceEnded = calculateRecurrenceEnded(recurrenceTemplate);
         setRecurrenceEnded(isRecurrenceEnded);
         // Edge case, if the recurrence is ended, it should not be enabled

--- a/frontend/components/events/EventDetails.tsx
+++ b/frontend/components/events/EventDetails.tsx
@@ -6,7 +6,7 @@ import { TagGroup } from "../TagGroup";
 import MobileEventPayment from "../mobile/MobileEventPayment";
 import EventPayment from "./EventPayment";
 
-export { MAX_TICKETS_PER_ORDER } from "@/interfaces/EventTypes";
+export { DEFAULT_MAX_TICKETS_PER_ORDER } from "@/interfaces/EventTypes";
 
 interface EventDetailsProps {
   eventData: EventData;

--- a/frontend/components/events/EventDetails.tsx
+++ b/frontend/components/events/EventDetails.tsx
@@ -6,13 +6,13 @@ import { TagGroup } from "../TagGroup";
 import MobileEventPayment from "../mobile/MobileEventPayment";
 import EventPayment from "./EventPayment";
 
+export { MAX_TICKETS_PER_ORDER } from "@/interfaces/EventTypes";
+
 interface EventDetailsProps {
   eventData: EventData;
   eventTags: Tag[];
   setLoading: (value: boolean) => void;
 }
-
-export const MAX_TICKETS_PER_ORDER = 7;
 
 export function EventDetails(props: EventDetailsProps) {
   const { eventData, eventTags, setLoading } = props;
@@ -37,6 +37,7 @@ export function EventDetails(props: EventDetailsProps) {
               eventLink={eventData.eventLink}
               organiserId={eventData.organiserId}
               waitlistEnabled={eventData.waitlistEnabled}
+              maxTicketsPerTransaction={eventData.maxTicketsPerTransaction}
             />
           </div>
 
@@ -69,6 +70,7 @@ export function EventDetails(props: EventDetailsProps) {
               eventLink={eventData.eventLink}
               organiserId={eventData.organiserId}
               waitlistEnabled={eventData.waitlistEnabled}
+              maxTicketsPerTransaction={eventData.maxTicketsPerTransaction}
             />
           </div>
         </div>

--- a/frontend/components/events/EventPayment.tsx
+++ b/frontend/components/events/EventPayment.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { EventId } from "@/interfaces/EventTypes";
+import { EventId, MAX_TICKETS_PER_ORDER } from "@/interfaces/EventTypes";
 import { UserId } from "@/interfaces/UserTypes";
 import { duration, timestampToDateString, timestampToTimeOfDay } from "@/services/src/datetimeUtils";
 import { getStoredFulfilmentSessionId } from "@/services/src/fulfilment/fulfilmentUtils/fulfilmentUtils";
@@ -16,7 +16,6 @@ import { Timestamp } from "firebase/firestore";
 import { useMemo, useState } from "react";
 import BookingButton from "./BookingButton";
 import ContactEventButton from "./ContactEventButton";
-import { MAX_TICKETS_PER_ORDER } from "./EventDetails";
 import JoinWaitlistButton from "@/components/waitlist/JoinWaitlistButton";
 import { WAITLIST_ENABLED } from "@/services/src/waitlist/waitlistService";
 
@@ -35,24 +34,30 @@ interface EventPaymentProps {
   eventLink: string;
   organiserId: UserId;
   waitlistEnabled: boolean;
+  maxTicketsPerTransaction?: number;
 }
 
 export default function EventPayment(props: EventPaymentProps) {
   const { startDate, endDate, registrationEndDate, paused } = props;
 
+  const effectiveMax = Math.min(
+    props.maxTicketsPerTransaction ?? MAX_TICKETS_PER_ORDER,
+    MAX_TICKETS_PER_ORDER
+  );
+
   // Memoize to avoid re-running localStorage checks on every render
   const ticketsWithStoredSessions = useMemo(() => {
     const sessions: number[] = [];
-    for (let i = 1; i <= MAX_TICKETS_PER_ORDER; i++) {
+    for (let i = 1; i <= effectiveMax; i++) {
       const storedSession = getStoredFulfilmentSessionId(props.eventId, i);
       if (storedSession !== null) {
         sessions.push(i);
       }
     }
     return sessions;
-  }, [props.eventId]);
+  }, [props.eventId, effectiveMax]);
 
-  const vacancyBasedCounts = Array.from({ length: Math.min(props.vacancy, MAX_TICKETS_PER_ORDER) }, (_, i) => i + 1);
+  const vacancyBasedCounts = Array.from({ length: Math.min(props.vacancy, effectiveMax) }, (_, i) => i + 1);
   // Merge with stored ticket counts and deduplicate
   const allCounts = [...new Set([...vacancyBasedCounts, ...ticketsWithStoredSessions])].sort((a, b) => a - b);
 
@@ -135,7 +140,7 @@ export default function EventPayment(props: EventPaymentProps) {
                       value={`${waitlistAttendeeCount}`}
                       onChange={handleWaitlistAttendeeCount}
                     >
-                      {Array.from({ length: MAX_TICKETS_PER_ORDER }, (_, i) => i + 1).map((count) => (
+                      {Array.from({ length: effectiveMax }, (_, i) => i + 1).map((count) => (
                         <Option key={`attendee-option-${count}`} value={`${count}`}>
                           {count} Attendee{count > 1 ? "s" : ""}
                         </Option>

--- a/frontend/components/events/EventPayment.tsx
+++ b/frontend/components/events/EventPayment.tsx
@@ -1,7 +1,12 @@
 "use client";
-import { EventId, MAX_TICKETS_PER_ORDER } from "@/interfaces/EventTypes";
+import { EventId } from "@/interfaces/EventTypes";
 import { UserId } from "@/interfaces/UserTypes";
 import { duration, timestampToDateString, timestampToTimeOfDay } from "@/services/src/datetimeUtils";
+import {
+  getBuyerMaxTicketsPerTransaction,
+  getBuyerTicketCountOptionsWithStoredSessions,
+  getTicketCountOptions,
+} from "@/services/src/events/eventsUtils/ticketLimits";
 import { getStoredFulfilmentSessionId } from "@/services/src/fulfilment/fulfilmentUtils/fulfilmentUtils";
 import { displayPrice } from "@/utilities/priceUtils";
 import {
@@ -13,7 +18,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { Option, Select } from "@material-tailwind/react";
 import { Timestamp } from "firebase/firestore";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import BookingButton from "./BookingButton";
 import ContactEventButton from "./ContactEventButton";
 import JoinWaitlistButton from "@/components/waitlist/JoinWaitlistButton";
@@ -40,26 +45,13 @@ interface EventPaymentProps {
 export default function EventPayment(props: EventPaymentProps) {
   const { startDate, endDate, registrationEndDate, paused } = props;
 
-  const effectiveMax = Math.min(
-    props.maxTicketsPerTransaction ?? MAX_TICKETS_PER_ORDER,
-    MAX_TICKETS_PER_ORDER
+  const effectiveMax = getBuyerMaxTicketsPerTransaction(props.maxTicketsPerTransaction);
+
+  const allCounts = getBuyerTicketCountOptionsWithStoredSessions(
+    props.vacancy,
+    props.maxTicketsPerTransaction,
+    (ticketCount) => getStoredFulfilmentSessionId(props.eventId, ticketCount) !== null
   );
-
-  // Memoize to avoid re-running localStorage checks on every render
-  const ticketsWithStoredSessions = useMemo(() => {
-    const sessions: number[] = [];
-    for (let i = 1; i <= effectiveMax; i++) {
-      const storedSession = getStoredFulfilmentSessionId(props.eventId, i);
-      if (storedSession !== null) {
-        sessions.push(i);
-      }
-    }
-    return sessions;
-  }, [props.eventId, effectiveMax]);
-
-  const vacancyBasedCounts = Array.from({ length: Math.min(props.vacancy, effectiveMax) }, (_, i) => i + 1);
-  // Merge with stored ticket counts and deduplicate
-  const allCounts = [...new Set([...vacancyBasedCounts, ...ticketsWithStoredSessions])].sort((a, b) => a - b);
 
   const [attendeeCount, setAttendeeCount] = useState<number>(allCounts[0] ?? 1);
   const handleAttendeeCount = (value?: string) => {
@@ -140,7 +132,7 @@ export default function EventPayment(props: EventPaymentProps) {
                       value={`${waitlistAttendeeCount}`}
                       onChange={handleWaitlistAttendeeCount}
                     >
-                      {Array.from({ length: effectiveMax }, (_, i) => i + 1).map((count) => (
+                      {getTicketCountOptions(effectiveMax).map((count) => (
                         <Option key={`attendee-option-${count}`} value={`${count}`}>
                           {count} Attendee{count > 1 ? "s" : ""}
                         </Option>

--- a/frontend/components/events/EventPaymentListBox.tsx
+++ b/frontend/components/events/EventPaymentListBox.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { getBuyerTicketCountOptions } from "@/services/src/events/eventsUtils/ticketLimits";
 import { SortByCategory } from "../Filter/FilterDialog";
 import ListBox from "../ListBox";
 
@@ -8,12 +9,10 @@ interface EventPaymentListBoxProps {
 }
 
 export default function EventPaymentListBox(props: EventPaymentListBoxProps) {
-  const MAX_OPTION_SIZE = 7;
-  const options = [];
-
-  for (let i = 1; i <= Math.min(MAX_OPTION_SIZE, props.vacancy); i++) {
-    options.push({ name: `${i} ${i == 1 ? "Guest" : "Guests"}`, value: i });
-  }
+  const options = getBuyerTicketCountOptions(props.vacancy).map((count) => ({
+    name: `${count} ${count === 1 ? "Guest" : "Guests"}`,
+    value: count,
+  }));
 
   return (
     <div className="p-[9%] mb-5 w-full">

--- a/frontend/components/events/create/forms/BasicForm.tsx
+++ b/frontend/components/events/create/forms/BasicForm.tsx
@@ -2,10 +2,16 @@
 
 import LocationAutocompleteForm from "@/components/utility/AutoComplete";
 import { SPORTS_CONFIG } from "@/config/SportsConfig";
+import { DEFAULT_MAX_TICKETS_PER_ORDER } from "@/interfaces/EventTypes";
 import { NewRecurrenceFormData } from "@/interfaces/RecurringEventTypes";
 import { UserData } from "@/interfaces/UserTypes";
 import { Logger } from "@/observability/logger";
 import { BOOKING_APPROVAL_ENABLED } from "@/services/featureFlags";
+import {
+  clampMaxTicketsPerTransaction,
+  getOrganiserMaxTicketsPerTransactionLimit,
+  getTicketCountOptions,
+} from "@/services/src/events/eventsUtils/ticketLimits";
 import { MIN_PRICE_AMOUNT_FOR_STRIPE_CHECKOUT_CENTS } from "@/services/src/stripe/stripeConstants";
 import { getStripeStandardAccountLink } from "@/services/src/stripe/stripeService";
 import { getRefreshAccountLinkUrl } from "@/services/src/stripe/stripeUtils";
@@ -47,6 +53,7 @@ export type BasicData = {
   promotionalCodesEnabled: boolean;
   waitlistEnabled: boolean;
   bookingApprovalEnabled: boolean;
+  maxTicketsPerTransaction: number;
   eventLink: string;
   newRecurrenceData: NewRecurrenceFormData;
 };
@@ -88,6 +95,7 @@ export function BasicInformation({
   promotionalCodesEnabled,
   waitlistEnabled,
   bookingApprovalEnabled,
+  maxTicketsPerTransaction,
   eventLink,
   newRecurrenceData,
   updateField,
@@ -201,6 +209,12 @@ export function BasicInformation({
     });
   };
 
+  const handleMaxTicketsPerTransactionChange = (value: string) => {
+    updateField({
+      maxTicketsPerTransaction: clampMaxTicketsPerTransaction(Number(value), capacity),
+    });
+  };
+
   const [customAmount, setCustomAmount] = useState(centsToDollars(price));
 
   const handleCustomAmountChange = (amount: number) => {
@@ -276,15 +290,21 @@ export function BasicInformation({
 
   const handlePaymentsActiveChange = (paymentsActive: string) => {
     const isActive = paymentsActive.toLowerCase() === "true";
-    updateField({ 
+    updateField({
       paymentsActive: isActive,
+      ...(isActive && {
+        maxTicketsPerTransaction: clampMaxTicketsPerTransaction(DEFAULT_MAX_TICKETS_PER_ORDER, capacity),
+      }),
       // Reset payment-related fields when payments are disabled
       ...(!isActive && {
         stripeFeeToCustomer: true,
-        promotionalCodesEnabled: false
-      })
+        promotionalCodesEnabled: false,
+        maxTicketsPerTransaction: clampMaxTicketsPerTransaction(DEFAULT_MAX_TICKETS_PER_ORDER, capacity),
+      }),
     });
   };
+
+  const maxTicketsAllowed = getOrganiserMaxTicketsPerTransactionLimit(capacity);
 
   return (
     <FormWrapper>
@@ -463,9 +483,12 @@ export function BasicInformation({
                   const value = parseInt(e.target.value);
                   if (!isNaN(value)) {
                     const maxValue = Math.max(value, 0);
-                    updateField({ capacity: maxValue });
+                    updateField({
+                      capacity: maxValue,
+                      maxTicketsPerTransaction: clampMaxTicketsPerTransaction(maxTicketsPerTransaction, maxValue),
+                    });
                   } else {
-                    updateField({ capacity: 0 });
+                    updateField({ capacity: 0, maxTicketsPerTransaction: 1 });
                   }
                 }}
                 className="rounded-md focus:ring-0"
@@ -689,6 +712,32 @@ export function BasicInformation({
                       </div>
                     </div>
                   )}
+                  <div>
+                    <label className="text-black text-lg font-semibold">
+                      What is the max number of tickets per transaction?
+                    </label>
+                    <p className="text-sm mb-5 mt-2">
+                      Customers can purchase up to this many tickets in a single checkout (up to {maxTicketsAllowed} for
+                      this event).
+                    </p>
+                    <div className="mt-4">
+                      <Select
+                        size="md"
+                        label="Max Tickets Per Transaction"
+                        value={`${maxTicketsPerTransaction}`}
+                        onChange={(e) => {
+                          const value = e || `${maxTicketsPerTransaction}`;
+                          handleMaxTicketsPerTransactionChange(value);
+                        }}
+                      >
+                        {getTicketCountOptions(maxTicketsAllowed).map((count) => (
+                          <Option key={`max-tickets-option-${count}`} value={`${count}`}>
+                            {count}
+                          </Option>
+                        ))}
+                      </Select>
+                    </div>
+                  </div>
                 </>
               )}
             </>

--- a/frontend/components/mobile/MobileEventPayment.tsx
+++ b/frontend/components/mobile/MobileEventPayment.tsx
@@ -1,18 +1,23 @@
 "use client";
 
-import { EventId, MAX_TICKETS_PER_ORDER } from "@/interfaces/EventTypes";
+import { EventId } from "@/interfaces/EventTypes";
 import { UserId } from "@/interfaces/UserTypes";
 import {
   formatMobileDifferentDayDateTime,
   formatMobileSameDayDateTime,
   timestampToDateString,
 } from "@/services/src/datetimeUtils";
+import {
+  getBuyerMaxTicketsPerTransaction,
+  getBuyerTicketCountOptionsWithStoredSessions,
+  getTicketCountOptions,
+} from "@/services/src/events/eventsUtils/ticketLimits";
 import { getStoredFulfilmentSessionId } from "@/services/src/fulfilment/fulfilmentUtils/fulfilmentUtils";
 import { displayPrice } from "@/utilities/priceUtils";
 import { CalendarDaysIcon, CurrencyDollarIcon, MapPinIcon } from "@heroicons/react/24/outline";
 import { Option, Select } from "@material-tailwind/react";
 import { Timestamp } from "firebase/firestore";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import BookingButton from "../events/BookingButton";
 import ContactEventButton from "../events/ContactEventButton";
 import JoinWaitlistButton from "../waitlist/JoinWaitlistButton";
@@ -39,27 +44,13 @@ interface MobileEventPaymentProps {
 export default function MobileEventPayment(props: MobileEventPaymentProps) {
   const { startDate, endDate, registrationEndDate, paused } = props;
 
-  const effectiveMax = Math.min(
-    props.maxTicketsPerTransaction ?? MAX_TICKETS_PER_ORDER,
-    MAX_TICKETS_PER_ORDER
+  const effectiveMax = getBuyerMaxTicketsPerTransaction(props.maxTicketsPerTransaction);
+
+  const allCounts = getBuyerTicketCountOptionsWithStoredSessions(
+    props.vacancy,
+    props.maxTicketsPerTransaction,
+    (ticketCount) => getStoredFulfilmentSessionId(props.eventId, ticketCount) !== null
   );
-
-  // Memoize to avoid re-running localStorage checks on every render
-  const storedTicketCounts = useMemo(() => {
-    const sessions: number[] = [];
-    for (let i = 1; i <= effectiveMax; i++) {
-      const storedSession = getStoredFulfilmentSessionId(props.eventId, i);
-      if (storedSession !== null) {
-        sessions.push(i);
-      }
-    }
-    return sessions;
-  }, [props.eventId, effectiveMax]);
-
-  // Get ticket counts from vacancy (1 to min(vacancy, effectiveMax))
-  const vacancyBasedCounts = Array.from({ length: Math.min(props.vacancy, effectiveMax) }, (_, i) => i + 1);
-  // Merge with stored ticket counts and deduplicate
-  const allCounts = [...new Set([...vacancyBasedCounts, ...storedTicketCounts])].sort((a, b) => a - b);
 
   const [attendeeCount, setAttendeeCount] = useState<number>(allCounts[0] ?? 1);
 
@@ -137,7 +128,7 @@ export default function MobileEventPayment(props: MobileEventPaymentProps) {
                       value={`${waitlistAttendeeCount}`}
                       onChange={handleWaitlistAttendeeCount}
                     >
-                      {Array.from({ length: effectiveMax }, (_, i) => i + 1).map((count) => (
+                      {getTicketCountOptions(effectiveMax).map((count) => (
                         <Option key={`attendee-option-${count}`} value={`${count}`}>
                           {count} Attendee{count > 1 ? "s" : ""}
                         </Option>

--- a/frontend/components/mobile/MobileEventPayment.tsx
+++ b/frontend/components/mobile/MobileEventPayment.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { EventId } from "@/interfaces/EventTypes";
+import { EventId, MAX_TICKETS_PER_ORDER } from "@/interfaces/EventTypes";
 import { UserId } from "@/interfaces/UserTypes";
 import {
   formatMobileDifferentDayDateTime,
@@ -15,7 +15,6 @@ import { Timestamp } from "firebase/firestore";
 import { useMemo, useState } from "react";
 import BookingButton from "../events/BookingButton";
 import ContactEventButton from "../events/ContactEventButton";
-import { MAX_TICKETS_PER_ORDER } from "../events/EventDetails";
 import JoinWaitlistButton from "../waitlist/JoinWaitlistButton";
 import { WAITLIST_ENABLED } from "@/services/src/waitlist/waitlistService";
 
@@ -34,25 +33,31 @@ interface MobileEventPaymentProps {
   eventLink: string;
   organiserId: UserId;
   waitlistEnabled: boolean;
+  maxTicketsPerTransaction?: number;
 }
 
 export default function MobileEventPayment(props: MobileEventPaymentProps) {
   const { startDate, endDate, registrationEndDate, paused } = props;
 
+  const effectiveMax = Math.min(
+    props.maxTicketsPerTransaction ?? MAX_TICKETS_PER_ORDER,
+    MAX_TICKETS_PER_ORDER
+  );
+
   // Memoize to avoid re-running localStorage checks on every render
   const storedTicketCounts = useMemo(() => {
     const sessions: number[] = [];
-    for (let i = 1; i <= MAX_TICKETS_PER_ORDER; i++) {
+    for (let i = 1; i <= effectiveMax; i++) {
       const storedSession = getStoredFulfilmentSessionId(props.eventId, i);
       if (storedSession !== null) {
         sessions.push(i);
       }
     }
     return sessions;
-  }, [props.eventId]);
+  }, [props.eventId, effectiveMax]);
 
-  // Get ticket counts from vacancy (1 to min(vacancy, MAX_TICKETS_PER_ORDER))
-  const vacancyBasedCounts = Array.from({ length: Math.min(props.vacancy, MAX_TICKETS_PER_ORDER) }, (_, i) => i + 1);
+  // Get ticket counts from vacancy (1 to min(vacancy, effectiveMax))
+  const vacancyBasedCounts = Array.from({ length: Math.min(props.vacancy, effectiveMax) }, (_, i) => i + 1);
   // Merge with stored ticket counts and deduplicate
   const allCounts = [...new Set([...vacancyBasedCounts, ...storedTicketCounts])].sort((a, b) => a - b);
 
@@ -132,7 +137,7 @@ export default function MobileEventPayment(props: MobileEventPaymentProps) {
                       value={`${waitlistAttendeeCount}`}
                       onChange={handleWaitlistAttendeeCount}
                     >
-                      {Array.from({ length: MAX_TICKETS_PER_ORDER }, (_, i) => i + 1).map((count) => (
+                      {Array.from({ length: effectiveMax }, (_, i) => i + 1).map((count) => (
                         <Option key={`attendee-option-${count}`} value={`${count}`}>
                           {count} Attendee{count > 1 ? "s" : ""}
                         </Option>

--- a/frontend/components/organiser/event/attendee/AddAttendeeDialog.tsx
+++ b/frontend/components/organiser/event/attendee/AddAttendeeDialog.tsx
@@ -3,6 +3,7 @@ import { EventData, EventId, EventMetadata, OrderId, TicketId } from "@/interfac
 import { EMPTY_ORDER_DEFAULTS, Order, OrderAndTicketStatus, OrderAndTicketType } from "@/interfaces/OrderTypes";
 import { EMPTY_TICKET, Ticket } from "@/interfaces/TicketTypes";
 import { addAttendee } from "@/services/src/attendee/attendeeService";
+import { clampTicketQuantity } from "@/services/src/events/eventsUtils/ticketLimits";
 import { Description, Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
 import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
 import { Alert, Input } from "@material-tailwind/react";
@@ -223,7 +224,7 @@ const InviteAttendeeDialog = ({
                           onChange={(e) => {
                             const value = parseInt(e.target.value);
                             if (!isNaN(value)) {
-                              const capped = Math.min(Math.max(value, 1), eventData.vacancy);
+                              const capped = clampTicketQuantity(value, 1, eventData.vacancy);
                               setNumTickets(capped.toString());
                             } else {
                               setNumTickets("1");

--- a/frontend/components/organiser/event/attendee/EditAttendeeTicketsDialog.tsx
+++ b/frontend/components/organiser/event/attendee/EditAttendeeTicketsDialog.tsx
@@ -4,6 +4,7 @@ import { EventData, EventId, EventMetadata } from "@/interfaces/EventTypes";
 import { Order } from "@/interfaces/OrderTypes";
 import { Ticket } from "@/interfaces/TicketTypes";
 import { setAttendeeTickets } from "@/services/src/attendee/attendeeService";
+import { clampTicketQuantity } from "@/services/src/events/eventsUtils/ticketLimits";
 import { getEventById } from "@/services/src/events/eventsService";
 import { getOrderById } from "@/services/src/tickets/orderService";
 import { getTicketsByIds } from "@/services/src/tickets/ticketService";
@@ -162,7 +163,7 @@ export const EditAttendeeTicketsDialog = ({
                           onChange={(e) => {
                             const value = parseInt(e.target.value);
                             if (!isNaN(value)) {
-                              const capped = Math.min(Math.max(value, 0), numTickets + eventData.vacancy);
+                              const capped = clampTicketQuantity(value, 0, numTickets + eventData.vacancy);
                               setNewNumTickets(capped.toString());
                             } else {
                               setNewNumTickets("0");

--- a/frontend/components/organiser/event/settings/EventDrilldownSettingsPage.tsx
+++ b/frontend/components/organiser/event/settings/EventDrilldownSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { BlackHighlightButton } from "@/components/elements/HighlightButton";
+import { MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP } from "@/interfaces/EventTypes";
 import { useUser } from "@/components/utility/UserContext";
 import { EventId } from "@/interfaces/EventTypes";
 import { Order } from "@/interfaces/OrderTypes";
@@ -9,9 +10,10 @@ import { archiveAndDeleteEvent, updateEventById } from "@/services/src/events/ev
 import { bustEventsLocalStorageCache } from "@/services/src/events/eventsUtils/getEventsUtils";
 import { sendEmailOnDeleteEventV2 } from "@/services/src/loops/loopsService";
 import { WAITLIST_ENABLED } from "@/services/src/waitlist/waitlistService";
+import { NumberInput } from "@mantine/core";
 import { Timestamp } from "firebase/firestore";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { LabelledSwitch } from "../../../elements/LabelledSwitch";
 import DeleteEventModal from "./DeleteEventModal";
 
@@ -37,6 +39,9 @@ interface EventDrilldownSettingsPageProps {
   setBookingApprovalEnabled: (event: boolean) => void;
   showAttendeesOnEventPage: boolean;
   setShowAttendeesOnEventPage: (event: boolean) => void;
+  maxTicketsPerTransaction: number;
+  setMaxTicketsPerTransaction: (n: number) => void;
+  eventCapacity: number;
 }
 
 const EventDrilldownSettingsPage = ({
@@ -61,6 +66,9 @@ const EventDrilldownSettingsPage = ({
   setBookingApprovalEnabled,
   showAttendeesOnEventPage,
   setShowAttendeesOnEventPage,
+  maxTicketsPerTransaction,
+  setMaxTicketsPerTransaction,
+  eventCapacity,
 }: EventDrilldownSettingsPageProps) => {
   const [modalOpen, setModalOpen] = useState(false);
   const { user, auth } = useUser();
@@ -91,6 +99,17 @@ const EventDrilldownSettingsPage = ({
 
   const handleDeleteEvent = () => {
     setModalOpen(true);
+  };
+
+  const maxTicketsAllowed = useMemo(
+    () => Math.max(1, Math.min(eventCapacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP)),
+    [eventCapacity]
+  );
+
+  const persistMaxTickets = (next: number) => {
+    const clamped = Math.max(1, Math.min(maxTicketsAllowed, Math.round(next)));
+    setMaxTicketsPerTransaction(clamped);
+    void updateEventById(eventId, { maxTicketsPerTransaction: clamped });
   };
 
   return (
@@ -189,6 +208,31 @@ const EventDrilldownSettingsPage = ({
           });
         }}
       />
+      <div className="flex w-full items-center gap-4">
+        <div>
+          <h3 className="font-bold">Max Tickets Per Transaction</h3>
+          <p className="text-core-text font-light text-sm">
+            Maximum number of tickets a customer can purchase in a single transaction (up to{" "}
+            {Math.min(eventCapacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP)} for this event).
+          </p>
+        </div>
+        <NumberInput
+          className="ml-auto w-28 shrink-0"
+          min={1}
+          max={maxTicketsAllowed}
+          value={maxTicketsPerTransaction}
+          onChange={(val) => {
+            if (val === "" || val === undefined) {
+              return;
+            }
+            const n = typeof val === "number" ? val : Number(val);
+            if (!Number.isFinite(n)) {
+              return;
+            }
+            persistMaxTickets(n);
+          }}
+        />
+      </div>
       <BlackHighlightButton
         text="Delete Event"
         onClick={() => {

--- a/frontend/components/organiser/event/settings/EventDrilldownSettingsPage.tsx
+++ b/frontend/components/organiser/event/settings/EventDrilldownSettingsPage.tsx
@@ -1,5 +1,4 @@
 import { BlackHighlightButton } from "@/components/elements/HighlightButton";
-import { MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP } from "@/interfaces/EventTypes";
 import { useUser } from "@/components/utility/UserContext";
 import { EventId } from "@/interfaces/EventTypes";
 import { Order } from "@/interfaces/OrderTypes";
@@ -8,12 +7,17 @@ import { Logger } from "@/observability/logger";
 import { BOOKING_APPROVAL_ENABLED } from "@/services/featureFlags";
 import { archiveAndDeleteEvent, updateEventById } from "@/services/src/events/eventsService";
 import { bustEventsLocalStorageCache } from "@/services/src/events/eventsUtils/getEventsUtils";
+import {
+  clampMaxTicketsPerTransaction,
+  getOrganiserMaxTicketsPerTransactionLimit,
+  getTicketCountOptions,
+} from "@/services/src/events/eventsUtils/ticketLimits";
 import { sendEmailOnDeleteEventV2 } from "@/services/src/loops/loopsService";
 import { WAITLIST_ENABLED } from "@/services/src/waitlist/waitlistService";
-import { NumberInput } from "@mantine/core";
+import { Option, Select } from "@material-tailwind/react";
 import { Timestamp } from "firebase/firestore";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { LabelledSwitch } from "../../../elements/LabelledSwitch";
 import DeleteEventModal from "./DeleteEventModal";
 
@@ -101,13 +105,10 @@ const EventDrilldownSettingsPage = ({
     setModalOpen(true);
   };
 
-  const maxTicketsAllowed = useMemo(
-    () => Math.max(1, Math.min(eventCapacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP)),
-    [eventCapacity]
-  );
+  const maxTicketsAllowed = getOrganiserMaxTicketsPerTransactionLimit(eventCapacity);
 
   const persistMaxTickets = (next: number) => {
-    const clamped = Math.max(1, Math.min(maxTicketsAllowed, Math.round(next)));
+    const clamped = clampMaxTicketsPerTransaction(next, eventCapacity);
     setMaxTicketsPerTransaction(clamped);
     void updateEventById(eventId, { maxTicketsPerTransaction: clamped });
   };
@@ -213,25 +214,31 @@ const EventDrilldownSettingsPage = ({
           <h3 className="font-bold">Max Tickets Per Transaction</h3>
           <p className="text-core-text font-light text-sm">
             Maximum number of tickets a customer can purchase in a single transaction (up to{" "}
-            {Math.min(eventCapacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP)} for this event).
+            {maxTicketsAllowed} for this event).
           </p>
         </div>
-        <NumberInput
-          className="ml-auto w-28 shrink-0"
-          min={1}
-          max={maxTicketsAllowed}
-          value={maxTicketsPerTransaction}
-          onChange={(val) => {
-            if (val === "" || val === undefined) {
+        <Select
+          className="text-black"
+          containerProps={{ className: "ml-auto w-28 shrink-0" }}
+          label="Tickets"
+          value={`${maxTicketsPerTransaction}`}
+          onChange={(value) => {
+            if (!value) {
               return;
             }
-            const n = typeof val === "number" ? val : Number(val);
+            const n = Number(value);
             if (!Number.isFinite(n)) {
               return;
             }
             persistMaxTickets(n);
           }}
-        />
+        >
+          {getTicketCountOptions(maxTicketsAllowed).map((count) => (
+            <Option key={`max-tickets-option-${count}`} value={`${count}`}>
+              {count}
+            </Option>
+          ))}
+        </Select>
       </div>
       <BlackHighlightButton
         text="Delete Event"

--- a/frontend/components/organiser/event/settings/EventDrilldownSettingsPage.tsx
+++ b/frontend/components/organiser/event/settings/EventDrilldownSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { BlackHighlightButton } from "@/components/elements/HighlightButton";
 import { useUser } from "@/components/utility/UserContext";
-import { EventId } from "@/interfaces/EventTypes";
+import { EventData, EventId } from "@/interfaces/EventTypes";
 import { Order } from "@/interfaces/OrderTypes";
 import { Ticket } from "@/interfaces/TicketTypes";
 import { Logger } from "@/observability/logger";
@@ -14,7 +14,7 @@ import {
 } from "@/services/src/events/eventsUtils/ticketLimits";
 import { sendEmailOnDeleteEventV2 } from "@/services/src/loops/loopsService";
 import { WAITLIST_ENABLED } from "@/services/src/waitlist/waitlistService";
-import { Option, Select } from "@material-tailwind/react";
+import { Option, Select, Spinner } from "@material-tailwind/react";
 import { Timestamp } from "firebase/firestore";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -78,6 +78,7 @@ const EventDrilldownSettingsPage = ({
   const { user, auth } = useUser();
   const logger = new Logger("EventDrilldownSettingsLogger");
   const [deleteLoading, setDeleteLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
   const onClose = () => {
     setModalOpen(false);
   };
@@ -107,10 +108,19 @@ const EventDrilldownSettingsPage = ({
 
   const maxTicketsAllowed = getOrganiserMaxTicketsPerTransactionLimit(eventCapacity);
 
+  const saveEventSettings = async (data: Partial<EventData>) => {
+    setSaving(true);
+    try {
+      await updateEventById(eventId, data);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const persistMaxTickets = (next: number) => {
     const clamped = clampMaxTicketsPerTransaction(next, eventCapacity);
     setMaxTicketsPerTransaction(clamped);
-    void updateEventById(eventId, { maxTicketsPerTransaction: clamped });
+    void saveEventSettings({ maxTicketsPerTransaction: clamped });
   };
 
   return (
@@ -121,7 +131,7 @@ const EventDrilldownSettingsPage = ({
         state={paused}
         setState={setPaused}
         updateData={(event: boolean) => {
-          updateEventById(eventId, {
+          void saveEventSettings({
             paused: event,
           });
         }}
@@ -132,7 +142,7 @@ const EventDrilldownSettingsPage = ({
         state={paymentsActive}
         setState={setPaymentsActive}
         updateData={(event: boolean) => {
-          updateEventById(eventId, {
+          void saveEventSettings({
             paymentsActive: event,
           });
         }}
@@ -145,7 +155,7 @@ const EventDrilldownSettingsPage = ({
         state={stripeFeeToCustomer}
         setState={setStripeFeeToCustomer}
         updateData={(event: boolean) => {
-          updateEventById(eventId, {
+          void saveEventSettings({
             stripeFeeToCustomer: event,
           });
         }}
@@ -156,7 +166,7 @@ const EventDrilldownSettingsPage = ({
         state={promotionalCodesEnabled}
         setState={setPromotionalCodesEnabled}
         updateData={(event: boolean) => {
-          updateEventById(eventId, {
+          void saveEventSettings({
             promotionalCodesEnabled: event,
           });
         }}
@@ -167,7 +177,7 @@ const EventDrilldownSettingsPage = ({
         state={hideVacancy}
         setState={setHideVacancy}
         updateData={(event: boolean) => {
-          updateEventById(eventId, {
+          void saveEventSettings({
             hideVacancy: event,
           });
         }}
@@ -179,7 +189,7 @@ const EventDrilldownSettingsPage = ({
           state={waitlistEnabled}
           setState={setWaitlistEnabled}
           updateData={(event: boolean) => {
-            updateEventById(eventId, {
+            void saveEventSettings({
               waitlistEnabled: event,
             });
           }}
@@ -192,7 +202,7 @@ const EventDrilldownSettingsPage = ({
           state={bookingApprovalEnabled}
           setState={setBookingApprovalEnabled}
           updateData={(event: boolean) => {
-            updateEventById(eventId, {
+            void saveEventSettings({
               bookingApprovalEnabled: event,
             });
           }}
@@ -204,7 +214,7 @@ const EventDrilldownSettingsPage = ({
         state={showAttendeesOnEventPage}
         setState={setShowAttendeesOnEventPage}
         updateData={(event: boolean) => {
-          updateEventById(eventId, {
+          void saveEventSettings({
             showAttendeesOnEventPage: event,
           });
         }}
@@ -256,6 +266,12 @@ const EventDrilldownSettingsPage = ({
         onConfirm={onConfirm}
         loading={deleteLoading}
       />
+      {saving && (
+        <div className="flex items-center gap-2 text-sm text-gray-500">
+          <Spinner className="h-4 w-4" />
+          <span>Saving...</span>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/components/organiser/event/settings/EventDrilldownSettingsPage.tsx
+++ b/frontend/components/organiser/event/settings/EventDrilldownSettingsPage.tsx
@@ -209,7 +209,7 @@ const EventDrilldownSettingsPage = ({
           });
         }}
       />
-      <div className="flex w-full items-center gap-4">
+      <div className="flex w-full flex-col gap-3">
         <div>
           <h3 className="font-bold">Max Tickets Per Transaction</h3>
           <p className="text-core-text font-light text-sm">
@@ -219,7 +219,7 @@ const EventDrilldownSettingsPage = ({
         </div>
         <Select
           className="text-black"
-          containerProps={{ className: "ml-auto w-28 shrink-0" }}
+          containerProps={{ className: "w-28" }}
           label="Tickets"
           value={`${maxTicketsPerTransaction}`}
           onChange={(value) => {

--- a/frontend/components/organiser/recurring-events/RecurringTemplateSettings.tsx
+++ b/frontend/components/organiser/recurring-events/RecurringTemplateSettings.tsx
@@ -1,11 +1,13 @@
 "use client";
 import { LabelledSwitch } from "@/components/elements/LabelledSwitch";
+import { MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP } from "@/interfaces/EventTypes";
 import { RecurrenceTemplateId } from "@/interfaces/RecurringEventTypes";
 import { updateRecurrenceTemplateEventData } from "@/services/src/recurringEvents/recurringEventsService";
 import { WAITLIST_ENABLED } from "@/services/src/waitlist/waitlistService";
 import { BOOKING_APPROVAL_ENABLED } from "@/services/featureFlags";
+import { NumberInput } from "@mantine/core";
 import { Spinner } from "@material-tailwind/react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 interface RecurringTemplateSettingsProps {
   recurrenceTemplateId: RecurrenceTemplateId;
@@ -23,6 +25,9 @@ interface RecurringTemplateSettingsProps {
   setBookingApprovalEnabled: (event: boolean) => void;
   showAttendeesOnEventPage: boolean;
   setShowAttendeesOnEventPage: (event: boolean) => void;
+  maxTicketsPerTransaction: number;
+  setMaxTicketsPerTransaction: (n: number) => void;
+  eventCapacity: number;
 }
 
 export const RecurringTemplateSettings = ({
@@ -41,8 +46,31 @@ export const RecurringTemplateSettings = ({
   setBookingApprovalEnabled,
   showAttendeesOnEventPage,
   setShowAttendeesOnEventPage,
+  maxTicketsPerTransaction,
+  setMaxTicketsPerTransaction,
+  eventCapacity,
 }: RecurringTemplateSettingsProps) => {
   const [loading, setLoading] = useState<boolean>(false);
+
+  const maxTicketsAllowed = useMemo(
+    () => Math.max(1, Math.min(eventCapacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP)),
+    [eventCapacity]
+  );
+
+  const persistMaxTickets = async (next: number) => {
+    const clamped = Math.max(1, Math.min(maxTicketsAllowed, Math.round(next)));
+    setLoading(true);
+    const success = await updateRecurrenceTemplateEventData(recurrenceTemplateId, {
+      maxTicketsPerTransaction: clamped,
+    });
+    if (success) {
+      setMaxTicketsPerTransaction(clamped);
+      setLoading(false);
+    } else {
+      window.location.reload();
+    }
+  };
+
   return (
     <div className="relative">
       <div className="flex flex-col space-y-4 mb-6 px-4 md:px-0">
@@ -171,6 +199,31 @@ export const RecurringTemplateSettings = ({
             }
           }}
         />
+        <div className="flex w-full items-center gap-4">
+          <div>
+            <h3 className="font-bold">Max Tickets Per Transaction</h3>
+            <p className="text-core-text font-light text-sm">
+              Maximum number of tickets a customer can purchase in a single transaction (up to{" "}
+              {Math.min(eventCapacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP)} for this template).
+            </p>
+          </div>
+          <NumberInput
+            className="ml-auto w-28 shrink-0"
+            min={1}
+            max={maxTicketsAllowed}
+            value={maxTicketsPerTransaction}
+            onChange={(val) => {
+              if (val === "" || val === undefined) {
+                return;
+              }
+              const n = typeof val === "number" ? val : Number(val);
+              if (!Number.isFinite(n)) {
+                return;
+              }
+              void persistMaxTickets(n);
+            }}
+          />
+        </div>
       </div>
       {loading && (
         <div className="bg-core-hover opacity-50 top-0 absolute h-full w-full flex justify-center items-center">

--- a/frontend/components/organiser/recurring-events/RecurringTemplateSettings.tsx
+++ b/frontend/components/organiser/recurring-events/RecurringTemplateSettings.tsx
@@ -230,12 +230,13 @@ export const RecurringTemplateSettings = ({
             ))}
           </Select>
         </div>
+        {loading && (
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <Spinner className="h-4 w-4" />
+            <span>Saving...</span>
+          </div>
+        )}
       </div>
-      {loading && (
-        <div className="bg-core-hover opacity-50 top-0 absolute h-full w-full flex justify-center items-center">
-          <Spinner className="w-8 h-8 opacity-100" />
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/components/organiser/recurring-events/RecurringTemplateSettings.tsx
+++ b/frontend/components/organiser/recurring-events/RecurringTemplateSettings.tsx
@@ -199,7 +199,7 @@ export const RecurringTemplateSettings = ({
             }
           }}
         />
-        <div className="flex w-full items-center gap-4">
+        <div className="flex w-full flex-col gap-3">
           <div>
             <h3 className="font-bold">Max Tickets Per Transaction</h3>
             <p className="text-core-text font-light text-sm">
@@ -209,7 +209,7 @@ export const RecurringTemplateSettings = ({
           </div>
           <Select
             className="text-black"
-            containerProps={{ className: "ml-auto w-28 shrink-0" }}
+            containerProps={{ className: "w-28" }}
             label="Tickets"
             value={`${maxTicketsPerTransaction}`}
             onChange={(value) => {

--- a/frontend/components/organiser/recurring-events/RecurringTemplateSettings.tsx
+++ b/frontend/components/organiser/recurring-events/RecurringTemplateSettings.tsx
@@ -1,13 +1,16 @@
 "use client";
 import { LabelledSwitch } from "@/components/elements/LabelledSwitch";
-import { MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP } from "@/interfaces/EventTypes";
 import { RecurrenceTemplateId } from "@/interfaces/RecurringEventTypes";
 import { updateRecurrenceTemplateEventData } from "@/services/src/recurringEvents/recurringEventsService";
 import { WAITLIST_ENABLED } from "@/services/src/waitlist/waitlistService";
 import { BOOKING_APPROVAL_ENABLED } from "@/services/featureFlags";
-import { NumberInput } from "@mantine/core";
-import { Spinner } from "@material-tailwind/react";
-import { useMemo, useState } from "react";
+import {
+  clampMaxTicketsPerTransaction,
+  getOrganiserMaxTicketsPerTransactionLimit,
+  getTicketCountOptions,
+} from "@/services/src/events/eventsUtils/ticketLimits";
+import { Option, Select, Spinner } from "@material-tailwind/react";
+import { useState } from "react";
 
 interface RecurringTemplateSettingsProps {
   recurrenceTemplateId: RecurrenceTemplateId;
@@ -52,13 +55,10 @@ export const RecurringTemplateSettings = ({
 }: RecurringTemplateSettingsProps) => {
   const [loading, setLoading] = useState<boolean>(false);
 
-  const maxTicketsAllowed = useMemo(
-    () => Math.max(1, Math.min(eventCapacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP)),
-    [eventCapacity]
-  );
+  const maxTicketsAllowed = getOrganiserMaxTicketsPerTransactionLimit(eventCapacity);
 
   const persistMaxTickets = async (next: number) => {
-    const clamped = Math.max(1, Math.min(maxTicketsAllowed, Math.round(next)));
+    const clamped = clampMaxTicketsPerTransaction(next, eventCapacity);
     setLoading(true);
     const success = await updateRecurrenceTemplateEventData(recurrenceTemplateId, {
       maxTicketsPerTransaction: clamped,
@@ -204,25 +204,31 @@ export const RecurringTemplateSettings = ({
             <h3 className="font-bold">Max Tickets Per Transaction</h3>
             <p className="text-core-text font-light text-sm">
               Maximum number of tickets a customer can purchase in a single transaction (up to{" "}
-              {Math.min(eventCapacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP)} for this template).
+              {maxTicketsAllowed} for this template).
             </p>
           </div>
-          <NumberInput
-            className="ml-auto w-28 shrink-0"
-            min={1}
-            max={maxTicketsAllowed}
-            value={maxTicketsPerTransaction}
-            onChange={(val) => {
-              if (val === "" || val === undefined) {
+          <Select
+            className="text-black"
+            containerProps={{ className: "ml-auto w-28 shrink-0" }}
+            label="Tickets"
+            value={`${maxTicketsPerTransaction}`}
+            onChange={(value) => {
+              if (!value) {
                 return;
               }
-              const n = typeof val === "number" ? val : Number(val);
+              const n = Number(value);
               if (!Number.isFinite(n)) {
                 return;
               }
               void persistMaxTickets(n);
             }}
-          />
+          >
+            {getTicketCountOptions(maxTicketsAllowed).map((count) => (
+              <Option key={`max-tickets-option-${count}`} value={`${count}`}>
+                {count}
+              </Option>
+            ))}
+          </Select>
         </div>
       </div>
       {loading && (

--- a/frontend/components/users/profile/CalendarEventCard.tsx
+++ b/frontend/components/users/profile/CalendarEventCard.tsx
@@ -1,8 +1,7 @@
 "use client";
 import BookingButton from "@/components/events/BookingButton";
 import ContactEventButton from "@/components/events/ContactEventButton";
-import { MAX_TICKETS_PER_ORDER } from "@/components/events/EventDetails";
-import { EventData } from "@/interfaces/EventTypes";
+import { EventData, MAX_TICKETS_PER_ORDER } from "@/interfaces/EventTypes";
 import { timestampToEventCardDateString } from "@/services/src/datetimeUtils";
 import { displayPrice } from "@/utilities/priceUtils";
 import { MapPinIcon } from "@heroicons/react/24/outline";
@@ -21,6 +20,11 @@ export default function CalendarEventCard({ event }: CalendarEventCardProps) {
   const [ticketCount, setTicketCount] = useState(1);
   const [loading, setLoading] = useState(false);
 
+  const effectiveMax = Math.min(
+    event.maxTicketsPerTransaction ?? MAX_TICKETS_PER_ORDER,
+    MAX_TICKETS_PER_ORDER
+  );
+
   const handleTicketCountChange = (value: string | undefined) => {
     if (value) {
       setTicketCount(parseInt(value));
@@ -31,7 +35,7 @@ export default function CalendarEventCard({ event }: CalendarEventCardProps) {
     <div className="flex gap-3 items-center">
       <div className="flex-shrink-0 md:min-w-64">
         <Select value={ticketCount.toString()} onChange={handleTicketCountChange} label="Tickets" disabled={loading}>
-          {Array.from({ length: Math.min(event.vacancy, MAX_TICKETS_PER_ORDER) }, (_, i) => i + 1).map((num) => (
+          {Array.from({ length: Math.min(event.vacancy, effectiveMax) }, (_, i) => i + 1).map((num) => (
             <Option key={num} value={num.toString()}>
               {num}
             </Option>

--- a/frontend/components/users/profile/CalendarEventCard.tsx
+++ b/frontend/components/users/profile/CalendarEventCard.tsx
@@ -1,8 +1,9 @@
 "use client";
 import BookingButton from "@/components/events/BookingButton";
 import ContactEventButton from "@/components/events/ContactEventButton";
-import { EventData, MAX_TICKETS_PER_ORDER } from "@/interfaces/EventTypes";
+import { EventData } from "@/interfaces/EventTypes";
 import { timestampToEventCardDateString } from "@/services/src/datetimeUtils";
+import { getBuyerTicketCountOptions } from "@/services/src/events/eventsUtils/ticketLimits";
 import { displayPrice } from "@/utilities/priceUtils";
 import { MapPinIcon } from "@heroicons/react/24/outline";
 import { Option, Select } from "@material-tailwind/react";
@@ -20,11 +21,6 @@ export default function CalendarEventCard({ event }: CalendarEventCardProps) {
   const [ticketCount, setTicketCount] = useState(1);
   const [loading, setLoading] = useState(false);
 
-  const effectiveMax = Math.min(
-    event.maxTicketsPerTransaction ?? MAX_TICKETS_PER_ORDER,
-    MAX_TICKETS_PER_ORDER
-  );
-
   const handleTicketCountChange = (value: string | undefined) => {
     if (value) {
       setTicketCount(parseInt(value));
@@ -35,7 +31,7 @@ export default function CalendarEventCard({ event }: CalendarEventCardProps) {
     <div className="flex gap-3 items-center">
       <div className="flex-shrink-0 md:min-w-64">
         <Select value={ticketCount.toString()} onChange={handleTicketCountChange} label="Tickets" disabled={loading}>
-          {Array.from({ length: Math.min(event.vacancy, effectiveMax) }, (_, i) => i + 1).map((num) => (
+          {getBuyerTicketCountOptions(event.vacancy, event.maxTicketsPerTransaction).map((num) => (
             <Option key={num} value={num.toString()}>
               {num}
             </Option>

--- a/frontend/interfaces/EventTypes.ts
+++ b/frontend/interfaces/EventTypes.ts
@@ -13,6 +13,12 @@ export type TicketId = Branded<string, "TicketId">;
 export const INVALID_LAT = -1;
 export const INVALID_LNG = -1;
 
+/** Hard ceiling on selectable tickets per checkout (legacy default when event field is absent). */
+export const MAX_TICKETS_PER_ORDER = 7;
+
+/** Organiser-configurable max is capped at this value. */
+export const MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP = 10;
+
 export type EventAttendees = { [emailHash: string]: number };
 
 interface AbstractEventData {
@@ -51,6 +57,7 @@ interface AbstractEventData {
   waitlistEnabled: boolean; // should default to true
   bookingApprovalEnabled: boolean; // should default to false
   showAttendeesOnEventPage: boolean; // should default to false
+  maxTicketsPerTransaction: number; // max tickets per checkout; should default to 10, capped at min(capacity, 10) in UI
 }
 
 export interface NewEventData extends AbstractEventData {}
@@ -109,6 +116,7 @@ export const EmptyEventData: EventData = {
   waitlistEnabled: true,
   bookingApprovalEnabled: false,
   showAttendeesOnEventPage: false,
+  maxTicketsPerTransaction: MAX_TICKETS_PER_ORDER,
 };
 
 export interface EventMetadata {

--- a/frontend/interfaces/EventTypes.ts
+++ b/frontend/interfaces/EventTypes.ts
@@ -13,8 +13,8 @@ export type TicketId = Branded<string, "TicketId">;
 export const INVALID_LAT = -1;
 export const INVALID_LNG = -1;
 
-/** Hard ceiling on selectable tickets per checkout (legacy default when event field is absent). */
-export const MAX_TICKETS_PER_ORDER = 7;
+/** Default max tickets per checkout when an event has no configured value. */
+export const DEFAULT_MAX_TICKETS_PER_ORDER = 7;
 
 /** Organiser-configurable max is capped at this value. */
 export const MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP = 10;
@@ -57,7 +57,7 @@ interface AbstractEventData {
   waitlistEnabled: boolean; // should default to true
   bookingApprovalEnabled: boolean; // should default to false
   showAttendeesOnEventPage: boolean; // should default to false
-  maxTicketsPerTransaction: number; // max tickets per checkout; should default to 10, capped at min(capacity, 10) in UI
+  maxTicketsPerTransaction: number; // max tickets per checkout; should default to 7, capped at min(capacity, 10) in UI
 }
 
 export interface NewEventData extends AbstractEventData {}
@@ -116,7 +116,7 @@ export const EmptyEventData: EventData = {
   waitlistEnabled: true,
   bookingApprovalEnabled: false,
   showAttendeesOnEventPage: false,
-  maxTicketsPerTransaction: MAX_TICKETS_PER_ORDER,
+  maxTicketsPerTransaction: DEFAULT_MAX_TICKETS_PER_ORDER,
 };
 
 export interface EventMetadata {

--- a/frontend/services/src/events/eventsUtils/getEventsUtils.ts
+++ b/frontend/services/src/events/eventsUtils/getEventsUtils.ts
@@ -3,7 +3,7 @@ import {
   EventData,
   EventDataWithoutOrganiser,
   EventId,
-  MAX_TICKETS_PER_ORDER,
+  DEFAULT_MAX_TICKETS_PER_ORDER,
 } from "@/interfaces/EventTypes";
 import { PublicUserData } from "@/interfaces/UserTypes";
 import {
@@ -19,6 +19,7 @@ import { db } from "../../firebase";
 import { getPublicUserById } from "../../users/usersService";
 import { EVENTS_REFRESH_MILLIS, EVENT_PATHS, LocalStorageKeys } from "../eventsConstants";
 import { eventServiceLogger } from "../eventsService";
+import { clampMaxTicketsPerTransaction } from "./ticketLimits";
 
 // const router = useRouter();
 
@@ -152,7 +153,10 @@ function getEventsDataFromLocalStorage(): EventData[] {
       waitlistEnabled: event.waitlistEnabled,
       bookingApprovalEnabled: event.bookingApprovalEnabled,
       showAttendeesOnEventPage: event.showAttendeesOnEventPage,
-      maxTicketsPerTransaction: event.maxTicketsPerTransaction ?? MAX_TICKETS_PER_ORDER,
+      maxTicketsPerTransaction: clampMaxTicketsPerTransaction(
+        event.maxTicketsPerTransaction ?? DEFAULT_MAX_TICKETS_PER_ORDER,
+        event.capacity
+      ),
     });
   });
   return eventsDataFinal;

--- a/frontend/services/src/events/eventsUtils/getEventsUtils.ts
+++ b/frontend/services/src/events/eventsUtils/getEventsUtils.ts
@@ -153,10 +153,7 @@ function getEventsDataFromLocalStorage(): EventData[] {
       waitlistEnabled: event.waitlistEnabled,
       bookingApprovalEnabled: event.bookingApprovalEnabled,
       showAttendeesOnEventPage: event.showAttendeesOnEventPage,
-      maxTicketsPerTransaction: clampMaxTicketsPerTransaction(
-        event.maxTicketsPerTransaction ?? DEFAULT_MAX_TICKETS_PER_ORDER,
-        event.capacity
-      ),
+      maxTicketsPerTransaction: event.maxTicketsPerTransaction
     });
   });
   return eventsDataFinal;

--- a/frontend/services/src/events/eventsUtils/getEventsUtils.ts
+++ b/frontend/services/src/events/eventsUtils/getEventsUtils.ts
@@ -1,4 +1,10 @@
-import { EmptyEventData, EventData, EventDataWithoutOrganiser, EventId } from "@/interfaces/EventTypes";
+import {
+  EmptyEventData,
+  EventData,
+  EventDataWithoutOrganiser,
+  EventId,
+  MAX_TICKETS_PER_ORDER,
+} from "@/interfaces/EventTypes";
 import { PublicUserData } from "@/interfaces/UserTypes";
 import {
   CollectionReference,
@@ -146,6 +152,7 @@ function getEventsDataFromLocalStorage(): EventData[] {
       waitlistEnabled: event.waitlistEnabled,
       bookingApprovalEnabled: event.bookingApprovalEnabled,
       showAttendeesOnEventPage: event.showAttendeesOnEventPage,
+      maxTicketsPerTransaction: event.maxTicketsPerTransaction ?? MAX_TICKETS_PER_ORDER,
     });
   });
   return eventsDataFinal;

--- a/frontend/services/src/events/eventsUtils/ticketLimits.ts
+++ b/frontend/services/src/events/eventsUtils/ticketLimits.ts
@@ -1,0 +1,50 @@
+import {
+  DEFAULT_MAX_TICKETS_PER_ORDER,
+  MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP,
+} from "@/interfaces/EventTypes";
+
+export function clampTicketQuantity(quantity: number, min: number, max: number): number {
+  return Math.min(Math.max(quantity, min), max);
+}
+
+export function getBuyerMaxTicketsPerTransaction(maxTicketsPerTransaction?: number): number {
+  return clampTicketQuantity(
+    maxTicketsPerTransaction ?? DEFAULT_MAX_TICKETS_PER_ORDER,
+    1,
+    MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP
+  );
+}
+
+export function getOrganiserMaxTicketsPerTransactionLimit(capacity: number): number {
+  return Math.max(1, Math.min(capacity, MAX_TICKETS_PER_TRANSACTION_ORGANISER_CAP));
+}
+
+export function clampMaxTicketsPerTransaction(maxTicketsPerTransaction: number, capacity: number): number {
+  return clampTicketQuantity(
+    Math.round(maxTicketsPerTransaction),
+    1,
+    getOrganiserMaxTicketsPerTransactionLimit(capacity)
+  );
+}
+
+export function getTicketCountOptions(maxTickets: number): number[] {
+  return Array.from({ length: Math.max(0, maxTickets) }, (_, i) => i + 1);
+}
+
+export function getBuyerTicketCountOptions(vacancy: number, maxTicketsPerTransaction?: number): number[] {
+  const maxTickets = Math.min(vacancy, getBuyerMaxTicketsPerTransaction(maxTicketsPerTransaction));
+  return getTicketCountOptions(maxTickets);
+}
+
+export function getBuyerTicketCountOptionsWithStoredSessions(
+  vacancy: number,
+  maxTicketsPerTransaction: number | undefined,
+  hasStoredSession: (ticketCount: number) => boolean
+): number[] {
+  const maxTickets = getBuyerMaxTicketsPerTransaction(maxTicketsPerTransaction);
+  const storedSessionCounts = getTicketCountOptions(maxTickets).filter(hasStoredSession);
+
+  return [...new Set([...getBuyerTicketCountOptions(vacancy, maxTicketsPerTransaction), ...storedSessionCounts])].sort(
+    (a, b) => a - b
+  );
+}

--- a/functions/lib/functions/src/main/java/com/functions/events/models/AbstractEventData.java
+++ b/functions/lib/functions/src/main/java/com/functions/events/models/AbstractEventData.java
@@ -64,6 +64,8 @@ public abstract class AbstractEventData {
 	private Boolean waitlistEnabled = true; // Default to true
 	private Boolean bookingApprovalEnabled = false; // Optional field
 	private Boolean showAttendeesOnEventPage = false; // Optional field
+	@Nullable
+	private Integer maxTicketsPerTransaction = 10; // Max tickets per checkout; optional for legacy docs
 
 	@Data
 	public static class LocationLatLng {


### PR DESCRIPTION
## Why was your change needed?

Please detail here why you did the change you did.

## What was Changed?

Please detail here what were the main changes you made.

## Any extra notes for reviewers to know?

Write any extra notes you may have for the PR.
This may include specific code paths that need extra scrutiny, or how to review a specific portion of code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organisers can configure a per-transaction max tickets limit (default 7, organiser cap 10) for single and recurring events.
  * Event creation and settings UIs expose, validate and persist this setting; capacity changes clamp the value.
  * Buyer-facing ticket quantity selectors (desktop, mobile, calendar, waitlist) respect the configured cap and include stored-session-aware options.

* **Improvements**
  * Settings show a “Saving…” spinner during persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->