### PR TITLE
HOTFIX - properly handle free events ($0) on java stripe fulfilment webhook

### DIFF
--- a/functions/lib/functions/src/main/java/com/functions/stripe/handlers/StripeWebhookHandler.java
+++ b/functions/lib/functions/src/main/java/com/functions/stripe/handlers/StripeWebhookHandler.java
@@ -281,9 +281,8 @@ public class StripeWebhookHandler {
             String paymentIntentId;
             String captureMethod;
             if (isFreeCheckoutSession(fullSession.getAmountTotal())) {
-                // Stripe no-cost checkout sessions can complete without a PaymentIntent.
-                // Keep the fulfilment path moving and let downstream logic treat the order
-                // as immediately approved without payment metadata.
+                // Stripe no-cost checkout sessions can complete without a PaymentIntent:
+                // https://docs.stripe.com/payments/checkout/no-cost-orders
                 logger.info("[Webhook-{}] Free checkout session detected for session {}. amountTotal={}. Skipping payment intent lookup.",
                         uuid, checkoutSessionId, fullSession.getAmountTotal());
                 paymentIntentId = null;

--- a/functions/lib/functions/src/main/java/com/functions/stripe/handlers/StripeWebhookHandler.java
+++ b/functions/lib/functions/src/main/java/com/functions/stripe/handlers/StripeWebhookHandler.java
@@ -278,35 +278,46 @@ public class StripeWebhookHandler {
                 return false;
             }
             
-            // Retrieve payment intent and capture method
-            String paymentIntentId = fullSession.getPaymentIntent();
-            if (paymentIntentId == null || paymentIntentId.isBlank()) {
-                logger.error("[Webhook-{}] Payment intent ID is null or empty for session {}", uuid, checkoutSessionId);
-                return false;
-            }
-            
+            String paymentIntentId;
             String captureMethod;
-            try {
-                PaymentIntent paymentIntent = PaymentIntent.retrieve(
-                    paymentIntentId,
-                    com.stripe.net.RequestOptions.builder()
-                        .setStripeAccount(stripeAccount)
-                        .build()
-                );
-                
-                if (paymentIntent == null || paymentIntent.getCaptureMethod() == null) {
-                    logger.error("[Webhook-{}] Unable to retrieve payment intent or capture method. paymentIntentId={}", 
-                                uuid, paymentIntentId);
+            if (isFreeCheckoutSession(fullSession.getAmountTotal())) {
+                // Stripe no-cost checkout sessions can complete without a PaymentIntent.
+                // Keep the fulfilment path moving and let downstream logic treat the order
+                // as immediately approved without payment metadata.
+                logger.info("[Webhook-{}] Free checkout session detected for session {}. amountTotal={}. Skipping payment intent lookup.",
+                        uuid, checkoutSessionId, fullSession.getAmountTotal());
+                paymentIntentId = null;
+                captureMethod = null;
+            } else {
+                // Retrieve payment intent and capture method for paid checkouts.
+                paymentIntentId = fullSession.getPaymentIntent();
+                if (paymentIntentId == null || paymentIntentId.isBlank()) {
+                    logger.error("[Webhook-{}] Payment intent ID is null or empty for session {}", uuid, checkoutSessionId);
                     return false;
                 }
                 
-                captureMethod = paymentIntent.getCaptureMethod();
-                logger.info("[Webhook-{}] Retrieved capture method: {} for payment intent: {}", 
-                           uuid, captureMethod, paymentIntentId);
-                
-            } catch (Exception e) {
-                logger.error("[Webhook-{}] Failed to retrieve payment intent: {}", uuid, e.getMessage(), e);
-                return false;
+                try {
+                    PaymentIntent paymentIntent = PaymentIntent.retrieve(
+                        paymentIntentId,
+                        com.stripe.net.RequestOptions.builder()
+                            .setStripeAccount(stripeAccount)
+                            .build()
+                    );
+                    
+                    if (paymentIntent == null || paymentIntent.getCaptureMethod() == null) {
+                        logger.error("[Webhook-{}] Unable to retrieve payment intent or capture method. paymentIntentId={}", 
+                                    uuid, paymentIntentId);
+                        return false;
+                    }
+                    
+                    captureMethod = paymentIntent.getCaptureMethod();
+                    logger.info("[Webhook-{}] Retrieved capture method: {} for payment intent: {}", 
+                               uuid, captureMethod, paymentIntentId);
+                    
+                } catch (Exception e) {
+                    logger.error("[Webhook-{}] Failed to retrieve payment intent: {}", uuid, e.getMessage(), e);
+                    return false;
+                }
             }
             
             logger.info("[Webhook-{}] Attempting to fulfill completed event ticket purchase. session={}, eventId={}, " +
@@ -479,6 +490,10 @@ public class StripeWebhookHandler {
             return true;
         }
         return false;
+    }
+
+    static boolean isFreeCheckoutSession(Long amountTotal) {
+        return amountTotal != null && amountTotal == 0L;
     }
 
     static String readPayload(InputStream inputStream, long contentLength)

--- a/functions/lib/functions/src/test/java/com/functions/stripe/handlers/StripeWebhookHandlerTest.java
+++ b/functions/lib/functions/src/test/java/com/functions/stripe/handlers/StripeWebhookHandlerTest.java
@@ -1,0 +1,24 @@
+package com.functions.stripe.handlers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class StripeWebhookHandlerTest {
+
+    @Test
+    public void isFreeCheckoutSession_returnsTrueForZeroAmount() {
+        assertTrue(StripeWebhookHandler.isFreeCheckoutSession(0L));
+    }
+
+    @Test
+    public void isFreeCheckoutSession_returnsFalseForNullAmount() {
+        assertFalse(StripeWebhookHandler.isFreeCheckoutSession(null));
+    }
+
+    @Test
+    public void isFreeCheckoutSession_returnsFalseForPositiveAmount() {
+        assertFalse(StripeWebhookHandler.isFreeCheckoutSession(2500L));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where free checkout sessions (zero-amount transactions) would fail when payment information was unavailable. Free transactions now proceed to fulfillment successfully.

## Tests
* Added test coverage for free checkout session detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->