### PR TITLE
Move java stripe webhook out of GAC to its own endpoint

### DIFF
--- a/.github/workflows/sportshub_cloud_functions_deploy_ci.yml
+++ b/.github/workflows/sportshub_cloud_functions_deploy_ci.yml
@@ -168,6 +168,37 @@ jobs:
           fi
           PIDS+=($!)  # Capture PID of last background process ($!)
 
+          # Deploy stripeWebhookEndpoint in background (with conditional prod flags)
+          echo "Starting deployment of stripeWebhookEndpoint..."
+          if [ "${{ matrix.env }}" == "prod" ]; then
+            (gcloud functions deploy stripeWebhookEndpoint \
+              --entry-point com.functions.stripe.controllers.StripeWebhookEndpoint \
+              --runtime java17 \
+              --trigger-http \
+              --allow-unauthenticated \
+              --region australia-southeast1 \
+              --project $PROJECT_ID \
+              --set-env-vars PROJECT_NAME=$PROJECT_ID \
+              --memory 512 \
+              --concurrency 80 \
+              --min-instances 1 \
+              --max-instances 5 \
+              --cpu 1 \
+              --quiet 2>&1 | sed 's/^/[stripeWebhookEndpoint] /') &
+          else
+            (gcloud functions deploy stripeWebhookEndpoint \
+              --entry-point com.functions.stripe.controllers.StripeWebhookEndpoint \
+              --runtime java17 \
+              --trigger-http \
+              --allow-unauthenticated \
+              --region australia-southeast1 \
+              --project $PROJECT_ID \
+              --set-env-vars PROJECT_NAME=$PROJECT_ID \
+              --memory 512 \
+              --quiet 2>&1 | sed 's/^/[stripeWebhookEndpoint] /') &
+          fi
+          PIDS+=($!)  # Capture PID of last background process ($!)
+
           # Wait for all background processes to complete and check their exit codes
           echo ""
           echo "Waiting for all deployments to complete..."

--- a/frontend/app/(footer)/fulfilment/[fulfilmentSessionId]/[fulfilmentEntityId]/page.tsx
+++ b/frontend/app/(footer)/fulfilment/[fulfilmentSessionId]/[fulfilmentEntityId]/page.tsx
@@ -26,14 +26,15 @@ import { HomeIcon } from "@heroicons/react/24/outline";
 import { Alert } from "@material-tailwind/react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 /**
  * Routing page for fulfilment session entities.
  */
 const FulfilmentSessionEntityPage = () => {
   const params = useParams<{ fulfilmentSessionId: FulfilmentSessionId; fulfilmentEntityId: FulfilmentEntityId }>();
-  const fulfilmentSessionEntityPageLogger = new Logger("fulfilmentSessionEntityPageLogger");
+  const { fulfilmentSessionId, fulfilmentEntityId } = params;
+  const fulfilmentSessionEntityPageLogger = useMemo(() => new Logger("fulfilmentSessionEntityPageLogger"), []);
   const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [getFulfilmentEntityInfoResponse, setGetFulfilmentEntityInfoResponse] =
@@ -52,42 +53,45 @@ const FulfilmentSessionEntityPage = () => {
   const [errorMessage, setErrorMessage] = useState("");
 
   useEffect(() => {
-    const fetchFulfilmentEntityInfo = async () => {
-      const { fulfilmentSessionId, fulfilmentEntityId } = params;
+    let cancelled = false;
+
+    const fetchFulfilmentInfo = async () => {
       try {
         const getFulfilmentEntityInfoResponse = await getFulfilmentEntityInfo(fulfilmentSessionId, fulfilmentEntityId);
-        setGetFulfilmentEntityInfoResponse(getFulfilmentEntityInfoResponse);
-      } catch (error) {
-        if (error instanceof NotFoundError) {
-          router.push("/not-found");
+        if (cancelled) {
           return;
         }
-        fulfilmentSessionEntityPageLogger.error(`Error fetching fulfilment entity info ${error}`);
-        router.push("/error");
-        return;
-      }
-    };
-    const fetchFulfilmentSessionInfo = async () => {
-      const { fulfilmentSessionId, fulfilmentEntityId } = params;
-      try {
+        setGetFulfilmentEntityInfoResponse(getFulfilmentEntityInfoResponse);
+
         const fulfilmentSessionInfo = await getFulfilmentSessionInfo(fulfilmentSessionId, fulfilmentEntityId);
+        if (cancelled) {
+          return;
+        }
         setFulfilmentSessionInfo(fulfilmentSessionInfo);
         fulfilmentSessionEntityPageLogger.info(`fulfilmentSessionInfo: ${JSON.stringify(fulfilmentSessionInfo)}`);
       } catch (error) {
-        if (error instanceof NotFoundError) {
-          router.push("/not-found");
+        if (cancelled) {
           return;
         }
-        fulfilmentSessionEntityPageLogger.error(`Error fetching fulfilment session info ${error}`);
-        router.push("/error");
+        if (error instanceof NotFoundError) {
+          router.replace("/not-found");
+          return;
+        }
+        fulfilmentSessionEntityPageLogger.error(`Error fetching fulfilment info ${error}`);
+        router.replace("/error");
         return;
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     };
 
-    Promise.all([fetchFulfilmentEntityInfo(), fetchFulfilmentSessionInfo()]).then(() => {
-      setLoading(false);
-    });
-  }, [params.fulfilmentSessionId, params.fulfilmentEntityId, router]);
+    fetchFulfilmentInfo();
+    return () => {
+      cancelled = true;
+    };
+  }, [fulfilmentSessionId, fulfilmentEntityId, fulfilmentSessionEntityPageLogger, router]);
 
   const handleValidationChange = (isValid: boolean) => {
     setAreAllRequiredFieldsFilled(isValid);
@@ -103,7 +107,36 @@ const FulfilmentSessionEntityPage = () => {
 
   useEffect(() => {
     setIsFormReady(false);
-  }, [params.fulfilmentSessionId, params.fulfilmentEntityId]);
+  }, [fulfilmentSessionId, fulfilmentEntityId]);
+
+  useEffect(() => {
+    if (
+      getFulfilmentEntityInfoResponse?.type !== FulfilmentEntityType.STRIPE &&
+      getFulfilmentEntityInfoResponse?.type !== FulfilmentEntityType.DELAYED_STRIPE
+    ) {
+      return;
+    }
+
+    if (getFulfilmentEntityInfoResponse.url === null) {
+      fulfilmentSessionEntityPageLogger.error(
+        `${getFulfilmentEntityInfoResponse.type} Fulfilment Entity URL is null when it should not be, fulfilmentSessionId: ${
+          fulfilmentSessionId
+        }, fulfilmentEntityId: ${fulfilmentEntityId}, getFulfilmentEntityInfoResponse: ${JSON.stringify(
+          getFulfilmentEntityInfoResponse
+        )}`
+      );
+      router.push("/error");
+      return;
+    }
+
+    router.push(getFulfilmentEntityInfoResponse.url.toString());
+  }, [
+    getFulfilmentEntityInfoResponse,
+    fulfilmentSessionId,
+    fulfilmentEntityId,
+    fulfilmentSessionEntityPageLogger,
+    router,
+  ]);
 
   const handleNext = async () => {
     try {
@@ -210,33 +243,13 @@ const FulfilmentSessionEntityPage = () => {
 
   switch (getFulfilmentEntityInfoResponse?.type) {
     case FulfilmentEntityType.STRIPE:
-      if (getFulfilmentEntityInfoResponse.url === null) {
-        fulfilmentSessionEntityPageLogger.error(
-          `Stripe Fulfilment Entity URL is null when it should not be, fulfilmentSessionId: ${
-            params.fulfilmentSessionId
-          }, fulfilmentEntityId: ${params.fulfilmentEntityId}, getFulfilmentEntityInfoResponse: ${JSON.stringify(
-            getFulfilmentEntityInfoResponse
-          )}`
-        );
-        router.push("/error");
-        return renderErrorAlert();
-      }
-      router.push(getFulfilmentEntityInfoResponse.url.toString());
-      return renderErrorAlert();
     case FulfilmentEntityType.DELAYED_STRIPE:
-      if (getFulfilmentEntityInfoResponse.url === null) {
-        fulfilmentSessionEntityPageLogger.error(
-          `Delayed Stripe Fulfilment Entity URL is null when it should not be, fulfilmentSessionId: ${
-            params.fulfilmentSessionId
-          }, fulfilmentEntityId: ${params.fulfilmentEntityId}, getFulfilmentEntityInfoResponse: ${JSON.stringify(
-            getFulfilmentEntityInfoResponse
-          )}`
-        );
-        router.push("/error");
-        return renderErrorAlert();
-      }
-      router.push(getFulfilmentEntityInfoResponse.url.toString());
-      return renderErrorAlert();
+      return (
+        <>
+          <Loading />
+          {renderErrorAlert()}
+        </>
+      );
     case FulfilmentEntityType.FORMS:
       if (getFulfilmentEntityInfoResponse.formId === null || getFulfilmentEntityInfoResponse.eventId === null) {
         fulfilmentSessionEntityPageLogger.error(
@@ -416,7 +429,7 @@ function EndFulfilmentHandler({
     return () => {
       cancelled = true;
     };
-  }, [fulfilmentSessionId, fulfilmentEntityId, url, router]);
+  }, [fulfilmentSessionId, fulfilmentEntityId, url, logger, router]);
 
   return <Loading />;
 }

--- a/frontend/app/(footer)/layout.tsx
+++ b/frontend/app/(footer)/layout.tsx
@@ -4,6 +4,10 @@ import type { Metadata, Viewport } from "next";
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#000000" },
+  ],
 };
 
 export const metadata: Metadata = {
@@ -11,11 +15,6 @@ export const metadata: Metadata = {
   title: "SPORTSHUB | Find your next social sport session!",
   description:
     "Discover and book local sports events on SPORTSHUB. Find volleyball, badminton, pickleball and more recreational sports activities near you.",
-
-  themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
-    { media: "(prefers-color-scheme: dark)", color: "#000000" },
-  ],
 
   icons: {
     icon: [

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/services/src/fulfilment/fulfilmentServices.ts
+++ b/frontend/services/src/fulfilment/fulfilmentServices.ts
@@ -16,6 +16,7 @@ import {
   InitCheckoutFulfilmentSessionResponse,
 } from "@/interfaces/FulfilmentTypes";
 import { EndpointType } from "@/interfaces/FunctionsTypes";
+import { NotFoundError } from "@/interfaces/exceptions/NotFoundError";
 import { Logger } from "@/observability/logger";
 import { executeGlobalAppControllerFunction } from "../functions/functionsUtils";
 import { getUrlWithCurrentHostname } from "../urlUtils";
@@ -295,6 +296,9 @@ export async function getFulfilmentEntityInfo(
 
     return response;
   } catch (error) {
+    if (error instanceof NotFoundError) {
+      throw error;
+    }
     fulfilmentServiceLogger.error(`getFulfilmentEntityInfo: Failed to fetch fulfilment entity info: ${error}`);
     throw error;
   }
@@ -326,6 +330,9 @@ export async function getFulfilmentSessionInfo(
     );
     return response;
   } catch (error) {
+    if (error instanceof NotFoundError) {
+      throw error;
+    }
     fulfilmentServiceLogger.error(`getFulfilmentSessionInfo: Failed to fetch fulfilment session info: ${error}`);
     throw error;
   }

--- a/frontend/services/src/functions/functionsUtils.ts
+++ b/frontend/services/src/functions/functionsUtils.ts
@@ -29,10 +29,7 @@ export async function executeGlobalAppControllerFunction<S, T>(endpointType: End
 
   if (rawResponse.status === 404) {
     const errorResponse = (await rawResponse.json()) as ErrorResponse;
-    functionsUtilsLogger.error(
-      `executeGlobalAppControllerFunction: Requested object not found. status=404 message=${errorResponse.errorMessage}`
-    );
-    throw new NotFoundError("Fulfilment object not found");
+    throw new NotFoundError(errorResponse.errorMessage || "Requested object not found");
   }
 
   if (!rawResponse.ok) {

--- a/functions/lib/functions/deployFunctionsToGCloud.sh
+++ b/functions/lib/functions/deployFunctionsToGCloud.sh
@@ -7,6 +7,7 @@
 # cleanupOldFulfilmentSessionsCron
 # completeFulfilmentSession
 # globalAppController
+# stripeWebhookEndpoint
 
 # Check if the function name is valid and it should be a list of function name and another list of endpoint class name
 
@@ -17,6 +18,7 @@ VALID_FUNCTIONS=(
     "cleanupOldFulfilmentSessionsCron"
     "completeFulfilmentSession"
     "globalAppController"
+    "stripeWebhookEndpoint"
 )
 
 VALID_ENDPOINTS=(
@@ -26,6 +28,7 @@ VALID_ENDPOINTS=(
     "com.functions.fulfilment.controllers.CleanupOldFulfilmentSessionsCronEndpoint"
     "com.functions.fulfilment.controllers.CompleteFulfilmentSessionEndpoint"
     "com.functions.global.controllers.GlobalAppController"
+    "com.functions.stripe.controllers.StripeWebhookEndpoint"
 )
 
 # Check for exactly 2 arguments
@@ -72,7 +75,7 @@ else
 fi
 
 EXTRA_DEPLOY_ARGS=()
-if [ "$ENVIRONMENT" == "prod" ] && [ "$FUNCTION_NAME" == "globalAppController" ]; then
+if [ "$ENVIRONMENT" == "prod" ] && [[ "$FUNCTION_NAME" == "globalAppController" || "$FUNCTION_NAME" == "stripeWebhookEndpoint" ]]; then
     EXTRA_DEPLOY_ARGS=(
         --concurrency 80
         --min-instances 1

--- a/functions/lib/functions/src/main/java/com/functions/stripe/controllers/StripeWebhookEndpoint.java
+++ b/functions/lib/functions/src/main/java/com/functions/stripe/controllers/StripeWebhookEndpoint.java
@@ -1,0 +1,54 @@
+package com.functions.stripe.controllers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.functions.global.controllers.AbstractConfiguredHttpFunction;
+import com.functions.global.models.responses.ErrorResponse;
+import com.functions.stripe.handlers.StripeWebhookHandler;
+import com.functions.utils.JavaUtils;
+import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpResponse;
+
+public class StripeWebhookEndpoint extends AbstractConfiguredHttpFunction {
+    private static final Logger logger = LoggerFactory.getLogger(StripeWebhookEndpoint.class);
+
+    @FunctionalInterface
+    interface StripeWebhookProcessor {
+        void handle(HttpRequest request, HttpResponse response) throws Exception;
+    }
+
+    private final StripeWebhookProcessor stripeWebhookProcessor;
+
+    public StripeWebhookEndpoint() {
+        this(StripeWebhookHandler::handleWebhook);
+    }
+
+    StripeWebhookEndpoint(StripeWebhookProcessor stripeWebhookProcessor) {
+        this.stripeWebhookProcessor = stripeWebhookProcessor;
+    }
+
+    @Override
+    public void service(HttpRequest request, HttpResponse response) throws Exception {
+        setResponseHeaders(response);
+
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            response.setStatusCode(204);
+            return;
+        }
+
+        try {
+            logger.info("Routing Stripe webhook request to StripeWebhookHandler");
+            stripeWebhookProcessor.handle(request, response);
+        } catch (Exception e) {
+            logger.error("Unhandled exception while processing Stripe webhook. uri={}", request.getUri(), e);
+            response.setStatusCode(500);
+            response.getWriter().write(JavaUtils.objectMapper.writeValueAsString(
+                    new ErrorResponse("Internal server error")));
+        }
+    }
+
+    private void setResponseHeaders(HttpResponse response) {
+        response.appendHeader("Content-Type", "application/json; charset=UTF-8");
+    }
+}

--- a/functions/lib/functions/src/main/java/com/functions/stripe/handlers/StripeWebhookHandler.java
+++ b/functions/lib/functions/src/main/java/com/functions/stripe/handlers/StripeWebhookHandler.java
@@ -29,7 +29,8 @@ import com.stripe.net.Webhook;
 
 /**
  * Handler for processing Stripe webhook events.
- * This is called from GlobalAppController when a Stripe webhook is detected.
+ * This is shared by the dedicated Stripe webhook endpoint and the legacy
+ * GlobalAppController webhook route.
  */
 public class StripeWebhookHandler {
     private static final Logger logger = LoggerFactory.getLogger(StripeWebhookHandler.class);


### PR DESCRIPTION
During migration, we will keep both the GAC entry point and also the new endpoint in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Stripe webhook endpoint is now available for integration

* **Infrastructure & Deployment**
  * Updated Cloud Functions deployment process to include the new endpoint
  * Added environment-specific runtime configurations (production vs. development)
  * Enhanced error handling and logging for webhook operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->