### PR TITLE
Fix too many parallel deploy

### DIFF
--- a/.github/workflows/sportshub_cloud_functions_deploy_ci.yml
+++ b/.github/workflows/sportshub_cloud_functions_deploy_ci.yml
@@ -239,6 +239,9 @@ jobs:
 
   deploy-python-firebase-functions:
     name: Deploy Python Firebase Functions to ${{ matrix.env }}
+    # To avoid hitting concurrent cloud/firebase function deployment limits to GCP, we must have python firebase
+    # functions deploy sequentially after java cloud run functions. We started consistently erroring out after
+    # having >13 functions deploying in parallel across both Java and Python.
     needs: deploy-java-cloud-run-functions
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/sportshub_cloud_functions_deploy_ci.yml
+++ b/.github/workflows/sportshub_cloud_functions_deploy_ci.yml
@@ -296,4 +296,4 @@ jobs:
         working-directory: functions
         run: |
           source venv/bin/activate
-          firebase deploy --only functions:move_inactive_events,functions:create_stripe_standard_account,functions:send_email_on_delete_event,functions:send_email_on_create_event,functions:email_reminder,functions:send_email_on_create_event_v2,functions:send_email_on_delete_event_v2 --force --debug
+          firebase deploy --only functions:move_inactive_events,functions:create_stripe_standard_account,functions:send_email_on_delete_event,functions:send_email_on_create_event,functions:email_reminder,functions:send_email_on_create_event_v2,functions:send_email_on_delete_event_v2 --force

--- a/.github/workflows/sportshub_cloud_functions_deploy_ci.yml
+++ b/.github/workflows/sportshub_cloud_functions_deploy_ci.yml
@@ -239,6 +239,7 @@ jobs:
 
   deploy-python-firebase-functions:
     name: Deploy Python Firebase Functions to ${{ matrix.env }}
+    needs: deploy-java-cloud-run-functions
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -292,4 +293,4 @@ jobs:
         working-directory: functions
         run: |
           source venv/bin/activate
-          firebase deploy --only functions:move_inactive_events,functions:create_stripe_standard_account,functions:send_email_on_delete_event,functions:send_email_on_create_event,functions:email_reminder,functions:send_email_on_create_event_v2,functions:send_email_on_delete_event_v2 --force
+          firebase deploy --only functions:move_inactive_events,functions:create_stripe_standard_account,functions:send_email_on_delete_event,functions:send_email_on_create_event,functions:email_reminder,functions:send_email_on_create_event_v2,functions:send_email_on_delete_event_v2 --force --debug


### PR DESCRIPTION
Python firebase functions deploy was failing, as it seems we were trying to deploy too many java cloud funcs and python firebase funcs at the same time, after adding the new java endpoint `stripeWebhookEndpoint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to enforce sequential execution of runtime-specific deployment jobs.
  * Enhanced deployment logging verbosity for improved troubleshooting and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->