### PR TITLE
Add waitlist notification cron processing and auto-removal on booking

### DIFF
--- a/functions/lib/functions/src/main/java/com/functions/events/repositories/EventsRepository.java
+++ b/functions/lib/functions/src/main/java/com/functions/events/repositories/EventsRepository.java
@@ -129,6 +129,45 @@ public class EventsRepository {
     }
 
     /**
+     * Get all active public events with waitlist enabled.
+     */
+    public static List<EventData> getActivePublicEventsWithWaitlistEnabled() {
+        logger.info("Querying active public events with waitlist enabled");
+
+        try {
+            Firestore db = FirebaseService.getFirestore();
+
+            Query query = db.collection(FirebaseService.CollectionPaths.EVENTS)
+                    .document(FirebaseService.CollectionPaths.ACTIVE)
+                    .collection(FirebaseService.CollectionPaths.PUBLIC)
+                    .whereEqualTo("waitlistEnabled", true);
+
+            QuerySnapshot querySnapshot = query.get().get();
+            List<EventData> events = new ArrayList<>();
+
+            for (QueryDocumentSnapshot document : querySnapshot.getDocuments()) {
+                EventData eventData = document.toObject(EventData.class);
+                if (eventData == null) {
+                    logger.warn("Failed to map document to EventData, skipping document with ID: {}", document.getId());
+                    continue;
+                }
+                eventData.setEventId(document.getId());
+                events.add(eventData);
+            }
+
+            logger.info("Found {} active public events with waitlist enabled", events.size());
+            return events;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("Interrupted while fetching active public events with waitlist enabled", e);
+            return Collections.emptyList();
+        } catch (ExecutionException e) {
+            logger.error("Failed to fetch active public events with waitlist enabled", e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
      * Gets the DocumentReference for an event by ID. Performs a read - must be called
      * before any writes in a transaction to satisfy Firestore's read-before-write rule.
      *

--- a/functions/lib/functions/src/main/java/com/functions/stripe/services/WebhookService.java
+++ b/functions/lib/functions/src/main/java/com/functions/stripe/services/WebhookService.java
@@ -31,6 +31,7 @@ import com.functions.tickets.models.OrderAndTicketStatus;
 import com.functions.tickets.models.Ticket;
 import com.functions.tickets.repositories.OrdersRepository;
 import com.functions.tickets.repositories.TicketsRepository;
+import com.functions.waitlist.services.WaitlistService;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.Timestamp;
 import com.google.cloud.firestore.DocumentReference;
@@ -1040,6 +1041,8 @@ public class WebhookService {
                     logger.warn("Was unable to send purchase email after EmailClient retries. orderId={}, customer={}",
                             orderId, customerEmail);
                 }
+
+                WaitlistService.removeUserFromWaitlistIfBooked(eventId, customerEmail);
             }
             
             logger.info("Successfully handled checkout.session.completed webhook event. session={}", checkoutSessionId);

--- a/functions/lib/functions/src/main/java/com/functions/tickets/services/BookingApprovalService.java
+++ b/functions/lib/functions/src/main/java/com/functions/tickets/services/BookingApprovalService.java
@@ -17,6 +17,7 @@ import com.functions.tickets.repositories.OrdersRepository;
 import com.functions.tickets.repositories.TicketsRepository;
 import com.functions.users.models.UserData;
 import com.functions.users.services.Users;
+import com.functions.waitlist.services.WaitlistService;
 import com.stripe.exception.StripeException;
 
 public class BookingApprovalService {
@@ -102,6 +103,7 @@ public class BookingApprovalService {
                 logger.warn("Failed to send purchase email after approving booking for orderId: {}", orderId);
             }
 
+            WaitlistService.removeUserFromWaitlistIfBooked(eventData.getEventId(), order.getEmail());
             return true;
         } catch (StripeException e) {
             logger.error(

--- a/functions/lib/functions/src/main/java/com/functions/waitlist/controllers/WaitlistNotificationCronEndpoint.java
+++ b/functions/lib/functions/src/main/java/com/functions/waitlist/controllers/WaitlistNotificationCronEndpoint.java
@@ -1,0 +1,32 @@
+package com.functions.waitlist.controllers;
+
+import com.functions.global.controllers.AbstractConfiguredHttpFunction;
+import com.functions.waitlist.services.WaitlistService;
+import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpResponse;
+
+public class WaitlistNotificationCronEndpoint extends AbstractConfiguredHttpFunction {
+    @Override
+    public void service(HttpRequest request, HttpResponse response) throws Exception {
+        response.appendHeader("Access-Control-Allow-Origin", "*");
+        response.appendHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+        response.appendHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+        response.appendHeader("Access-Control-Max-Age", "3600");
+
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            response.setStatusCode(204);
+            return;
+        }
+
+        if (!(request.getMethod().equalsIgnoreCase("GET"))) {
+            response.setStatusCode(405);
+            response.appendHeader("Allow", "GET");
+            response.getWriter().write("The WaitlistNotificationCronEndpoint only supports GET requests.");
+            return;
+        }
+
+        int notifiedCount = WaitlistService.processWaitlistNotificationsForAllEvents();
+        response.setStatusCode(200);
+        response.getWriter().write("Waitlist notification run complete. Notifications sent: " + notifiedCount);
+    }
+}

--- a/functions/lib/functions/src/main/java/com/functions/waitlist/services/WaitlistService.java
+++ b/functions/lib/functions/src/main/java/com/functions/waitlist/services/WaitlistService.java
@@ -9,6 +9,12 @@ import org.apache.commons.validator.routines.EmailValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.functions.emails.EmailService;
+import com.google.cloud.Timestamp;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -16,6 +22,7 @@ import java.util.Optional;
  */
 public class WaitlistService {
     private static final Logger logger = LoggerFactory.getLogger(WaitlistService.class);
+    private static final Duration WAITLIST_NOTIFICATION_COOLDOWN = Duration.ofHours(24);
 
     public static void joinEventWaitlist(String eventId, String email, String name, Integer ticketCount) {
         try {
@@ -71,5 +78,88 @@ public class WaitlistService {
                 emailHash, eventId, e);
             return false;
         }
+    }
+
+    public static int processWaitlistNotificationsForAllEvents() {
+        List<EventData> events = EventsRepository.getActivePublicEventsWithWaitlistEnabled();
+        int notifiedCount = 0;
+
+        for (EventData eventData : events) {
+            notifiedCount += processWaitlistNotificationsForEvent(eventData.getEventId());
+        }
+
+        logger.info("Completed waitlist notification run. Total notifications sent: {}", notifiedCount);
+        return notifiedCount;
+    }
+
+    public static int processWaitlistNotificationsForEvent(String eventId) {
+        EventData eventData = EventsRepository.getEventById(eventId).orElse(null);
+        if (eventData == null || !Boolean.TRUE.equals(eventData.getWaitlistEnabled())) {
+            return 0;
+        }
+
+        Integer vacancy = eventData.getVacancy();
+        if (vacancy == null || vacancy <= 0) {
+            return 0;
+        }
+
+        List<WaitlistEntry> waitlistEntries = WaitlistRepository.getWaitlistByEventId(eventId);
+        if (waitlistEntries.isEmpty()) {
+            return 0;
+        }
+
+        Instant now = Instant.now();
+        int notifiedCount = 0;
+        for (WaitlistEntry entry : waitlistEntries) {
+            if (entry.getEmail() == null || entry.getEmail().isBlank()) {
+                continue;
+            }
+            if (isWithinCooldown(entry.getNotifiedAt(), now)) {
+                continue;
+            }
+
+            boolean sent = EmailService.sendWaitlistEmailNotification(
+                    eventData.getName(),
+                    entry.getName(),
+                    eventData.getStartDate(),
+                    eventData.getEndDate(),
+                    eventData.getLocation(),
+                    entry.getEmail());
+            if (!sent) {
+                logger.warn("Failed to send waitlist notification for eventId={}, email={}", eventId, entry.getEmail());
+                continue;
+            }
+
+            try {
+                WaitlistRepository.updateNotifiedAt(eventId, entry.getEmail(), now);
+                notifiedCount++;
+            } catch (Exception e) {
+                logger.error("Failed to update notifiedAt for eventId={}, email={}", eventId, entry.getEmail(), e);
+            }
+        }
+
+        return notifiedCount;
+    }
+
+    public static void removeUserFromWaitlistIfBooked(String eventId, String email) {
+        if (eventId == null || eventId.isBlank() || email == null || email.isBlank()) {
+            return;
+        }
+
+        try {
+            WaitlistRepository.removeFromWaitlist(eventId, email);
+            String hashedEmail = WaitlistRepository.hashEmail(email);
+            logger.info("Removed booked user from waitlist if present. eventId={}, emailHash={}", eventId, hashedEmail);
+        } catch (Exception e) {
+            logger.warn("Failed to remove booked user from waitlist. eventId={}", eventId, e);
+        }
+    }
+
+    private static boolean isWithinCooldown(Timestamp notifiedAt, Instant now) {
+        if (notifiedAt == null) {
+            return false;
+        }
+        Instant lastNotified = Instant.ofEpochSecond(notifiedAt.getSeconds(), notifiedAt.getNanos());
+        return lastNotified.plus(WAITLIST_NOTIFICATION_COOLDOWN).isAfter(now);
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a scheduler-driven flow to notify waitlisted users when event spots open and prevent duplicate blasts by respecting a cooldown window. 
- Ensure users who successfully purchase tickets are removed from the waitlist to avoid stale entries and improve observability.

### Description
- Added a cron-friendly HTTP Cloud Function endpoint `WaitlistNotificationCronEndpoint` that triggers `WaitlistService.processWaitlistNotificationsForAllEvents()` and includes CORS/OPTIONS handling.  
- Added `EventsRepository.getActivePublicEventsWithWaitlistEnabled()` to query active/public events with `waitlistEnabled=true` for notification candidates.  
- Extended `WaitlistService` with `processWaitlistNotificationsForAllEvents()`, `processWaitlistNotificationsForEvent(eventId)`, and `removeUserFromWaitlistIfBooked(eventId, email)`, implemented a 24-hour `notifiedAt` cooldown guard, and only call `WaitlistRepository.updateNotifiedAt` after a successful `EmailService.sendWaitlistEmailNotification` send.  
- Wired removal-on-booking calls to `WaitlistService.removeUserFromWaitlistIfBooked` from the Stripe webhook checkout completion workflow and the manual booking approval (`APPROVE`) flow so purchasers are auto-removed from the waitlist. 

### Testing
- Ran the build verification compile: `cd functions/lib/functions && mvn -q -DskipTests compile` and the project compiled successfully.  
- No automated unit tests were added or modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3c4919f88326b2f4c9b64ce791d9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic waitlist notification processing for events with waitlist capabilities enabled
  * Waitlist members now receive notifications when spots become available
  * Integrated automatic waitlist cleanup when users successfully purchase tickets or receive booking approval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->