### PR TITLE
Enable Cloud Functions gen2 deployments and tighten waitlist deadline check

### DIFF
--- a/.github/workflows/sportshub_cloud_functions_deploy_ci.yml
+++ b/.github/workflows/sportshub_cloud_functions_deploy_ci.yml
@@ -75,6 +75,7 @@ jobs:
             --entry-point com.functions.events.controllers.UpdateRecurrenceTemplateEndpoint \
             --runtime java17 \
             --trigger-http \
+            --gen2 \
             --allow-unauthenticated \
             --region australia-southeast1 \
             --project $PROJECT_ID \
@@ -88,6 +89,7 @@ jobs:
             --entry-point com.functions.events.controllers.CreateRecurrenceTemplateEndpoint \
             --runtime java17 \
             --trigger-http \
+            --gen2 \
             --allow-unauthenticated \
             --region australia-southeast1 \
             --project $PROJECT_ID \
@@ -101,6 +103,7 @@ jobs:
             --entry-point com.functions.events.controllers.RecurringEventsCronEndpoint \
             --runtime java17 \
             --trigger-http \
+            --gen2 \
             --allow-unauthenticated \
             --region australia-southeast1 \
             --project $PROJECT_ID \
@@ -115,6 +118,7 @@ jobs:
             --entry-point com.functions.fulfilment.controllers.CleanupOldFulfilmentSessionsCronEndpoint \
             --runtime java17 \
             --trigger-http \
+            --gen2 \
             --allow-unauthenticated \
             --region australia-southeast1 \
             --project $PROJECT_ID \
@@ -129,6 +133,7 @@ jobs:
             --entry-point com.functions.fulfilment.controllers.DeleteFulfilmentSessionEndpoint \
             --runtime java17 \
             --trigger-http \
+            --gen2 \
             --allow-unauthenticated \
             --region australia-southeast1 \
             --project $PROJECT_ID \
@@ -143,6 +148,7 @@ jobs:
             --entry-point com.functions.fulfilment.controllers.CompleteFulfilmentSessionEndpoint \
             --runtime java17 \
             --trigger-http \
+            --gen2 \
             --allow-unauthenticated \
             --region australia-southeast1 \
             --project $PROJECT_ID \
@@ -158,6 +164,7 @@ jobs:
               --entry-point com.functions.global.controllers.GlobalAppController \
               --runtime java17 \
               --trigger-http \
+              --gen2 \
               --allow-unauthenticated \
               --region australia-southeast1 \
               --project $PROJECT_ID \
@@ -173,6 +180,7 @@ jobs:
               --entry-point com.functions.global.controllers.GlobalAppController \
               --runtime java17 \
               --trigger-http \
+              --gen2 \
               --allow-unauthenticated \
               --region australia-southeast1 \
               --project $PROJECT_ID \

--- a/functions/lib/functions/src/main/java/com/functions/waitlist/services/WaitlistNotificationService.java
+++ b/functions/lib/functions/src/main/java/com/functions/waitlist/services/WaitlistNotificationService.java
@@ -110,7 +110,7 @@ public class WaitlistNotificationService {
         Timestamp registrationDeadline = event.getRegistrationDeadline();
         if (registrationDeadline != null) {
             Instant registrationEnd = Instant.ofEpochSecond(registrationDeadline.getSeconds(), registrationDeadline.getNanos());
-            if (notificationTime.isAfter(registrationEnd)) {
+            if (!notificationTime.isBefore(registrationEnd)) {
                 logger.info("[WaitlistNotificationService] Skipping event past registration deadline: {}", eventId);
                 return new NotificationResult(0, 0);
             }


### PR DESCRIPTION
### Motivation
- Migrate Java Cloud Functions deployments to Cloud Functions gen2 for improved runtime and scaling behavior. 
- Prevent waitlist notifications from being sent when the notification time is exactly at or after the registration deadline to avoid off-by-one edge cases.

### Description
- Add the `--gen2` flag to all `gcloud functions deploy` invocations in the `sportshub_cloud_functions_deploy_ci.yml` workflow so Java functions are deployed using gen2. 
- Change the registration-deadline check in `WaitlistNotificationService` from `notificationTime.isAfter(registrationEnd)` to `!notificationTime.isBefore(registrationEnd)` so notifications are skipped when the notification time is equal to or after the deadline.

### Testing
- Updated the GitHub Actions deploy workflow to use gen2; no workflow runtime changes were made beyond adding the `--gen2` flag. 
- Ran the existing Java functions test suite (`mvn test`) against the modified module and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb49671224832695631e3f7a1ecb75)