### PR TITLE
Add 'Free vs Paid Events' docs and update event doc navigation

### DIFF
--- a/sportshub-blogs-docs/content/docs/organisers/events/create-event.md
+++ b/sportshub-blogs-docs/content/docs/organisers/events/create-event.md
@@ -3,7 +3,7 @@ title: Create Event
 weight: 1
 description: Learn to create your very first SPORTSHUB event!
 prev: /docs/organiser/events
-next: /docs/organiser/events/recurring-events
+next: /docs/organiser/events/free-vs-paid-events
 ---
 
 ## Overview
@@ -37,7 +37,7 @@ Complete the essential event details including:
 - Privacy settings (public/private)
 
 > [!TIP]
-> To create paid events, you'll need to have Stripe connected to your account. You can choose to absorb Stripe processing fees yourself or pass them on to participants by adjusting the settings in the Additional Settings during event creation.
+> Need help choosing between free and paid setup options? See [Free vs Paid Events](/docs/organiser/events/free-vs-paid-events).
 
 ### 3. Upload Event Images
 

--- a/sportshub-blogs-docs/content/docs/organisers/events/free-vs-paid-events.md
+++ b/sportshub-blogs-docs/content/docs/organisers/events/free-vs-paid-events.md
@@ -1,0 +1,39 @@
+---
+title: Free vs Paid Events
+weight: 2
+description: Understand booking and payment options for free and paid events.
+prev: /docs/organiser/events/create-event
+next: /docs/organiser/events/recurring-events
+---
+
+When creating an event, you'll choose whether your event is **Free** or **Paid**.
+
+## Free Events
+
+Free events can be set up in two ways:
+
+- **Take bookings in SPORTSHUB** so people can reserve a spot directly in the platform.
+- **Link to an external URL** if registrations happen somewhere else.
+
+If you want your free event to take bookings in SPORTSHUB, you still need to have a **linked Stripe account** on your organiser profile.
+
+> [!NOTE]
+> Free bookings are processed at **no cost** (no processing fee is charged).
+
+## Paid Events
+
+Paid events include a processing fee. You can decide whether to:
+
+- **Absorb the processing fee** yourself, or
+- **Pass the fee on** to participants.
+
+This fee covers:
+
+- SPORTSHUB platform fees, and
+- Credit card surcharges enforced by Stripe.
+
+## Getting Paid Out
+
+For paid events, funds are paid out to your connected bank account using the payout schedule configured in Stripe.
+
+In most cases, payouts are available on a **next-day** schedule, depending on your Stripe account settings and region.

--- a/sportshub-blogs-docs/content/docs/organisers/events/recurring-events.md
+++ b/sportshub-blogs-docs/content/docs/organisers/events/recurring-events.md
@@ -1,7 +1,7 @@
 ---
 title: Recurring Events
-weight: 2
-prev: /docs/organiser/events/create-event
+weight: 3
+prev: /docs/organiser/events/free-vs-paid-events
 next: /docs/organiser/events/custom-links
 ---
 


### PR DESCRIPTION
### Motivation
- Provide a dedicated reference that clarifies booking and payment options for free and paid events. 
- Improve the organiser docs navigation so the payment guidance appears in the event creation flow.

### Description
- Add a new documentation page `content/docs/organisers/events/free-vs-paid-events.md` explaining free vs paid event options, fees, and payout behavior. 
- Update `content/docs/organisers/events/create-event.md` to link to the new `Free vs Paid Events` guide from the event creation tip. 
- Adjust frontmatter navigation and ordering by updating `prev`/`next` and `weight` in `content/docs/organisers/events/recurring-events.md` to insert the new page into the sequence.

### Testing
- No automated tests were executed for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc521adca48326b8244ad999060780)