### PR TITLE
Add Dependabot with Monday scheduled auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/functions/lib/functions"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Australia/Sydney"
+    labels: ["dependencies", "java"]
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Australia/Sydney"
+    labels: ["dependencies", "npm"]
+
+  - package-ecosystem: "npm"
+    directory: "/sportshub-cli"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Australia/Sydney"
+    labels: ["dependencies", "npm"]
+
+  - package-ecosystem: "npm"
+    directory: "/infrastructure"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Australia/Sydney"
+    labels: ["dependencies", "npm"]
+
+  - package-ecosystem: "pip"
+    directory: "/functions"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Australia/Sydney"
+    labels: ["dependencies", "python"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Australia/Sydney"
+    labels: ["dependencies", "ci"]
+
+  - package-ecosystem: "gitsubmodules"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Australia/Sydney"
+    labels: ["dependencies"]

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,0 +1,52 @@
+# Merges Dependabot PRs every Monday at 18:00 AEST (08:00 UTC).
+# PRs are raised earlier the same day at 08:00 Australia/Sydney via dependabot.yml.
+#
+# Prerequisite: Settings → General → Pull Requests → Allow auto-merge
+name: Dependabot Monday auto-merge
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Monday 08:00 UTC = 18:00 AEST
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge eligible Dependabot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr list \
+            --repo "$REPO" \
+            --author "dependabot[bot]" \
+            --state open \
+            --json number,title,statusCheckRollup \
+            --jq '.[]
+              | select(
+                  (.title | test("bump.*from.*to"; "i")) and
+                  (
+                    (.title | test("bump.*from [0-9]+\\.[0-9]+\\.[0-9]+ to [0-9]+\\.[0-9]+\\."; "i")) or
+                    (.title | test("bump.*from [0-9]+\\.[0-9]+ to [0-9]+\\."; "i"))
+                  ) and
+                  (.statusCheckRollup | length > 0) and
+                  (.statusCheckRollup | all(.conclusion == "SUCCESS"))
+                )
+              | .number' \
+          | while read -r pr; do
+              TITLE=$(gh pr view "$pr" --repo "$REPO" --json title --jq '.title')
+              FROM_VERSION=$(echo "$TITLE" | grep -oP 'from \K[0-9]+(\.[0-9]+)*' | head -1)
+              TO_VERSION=$(echo "$TITLE" | grep -oP 'to \K[0-9]+(\.[0-9]+)*' | tail -1)
+              FROM_MAJOR=$(echo "$FROM_VERSION" | cut -d. -f1)
+              TO_MAJOR=$(echo "$TO_VERSION" | cut -d. -f1)
+              if [ "$FROM_MAJOR" = "$TO_MAJOR" ]; then
+                echo "Merging PR #$pr (patch or minor bump)"
+                gh pr merge "$pr" --repo "$REPO" --squash --auto
+              else
+                echo "Skipping PR #$pr (major version bump — needs manual review)"
+              fi
+            done


### PR DESCRIPTION
## Why was your change needed?

We need automated dependency updates across the monorepo without manual tracking, aligned with our Monday standup so the team can spot-check the webapp before merges go in.

## What was Changed?

- Added `.github/dependabot.yml` for Maven, npm (frontend, sportshub-cli, infrastructure), pip, GitHub Actions, and git submodules — PRs open every Monday at 8:00am Australia/Sydney.
- Added `.github/workflows/dependabot_automerge.yml` — scheduled every Monday at 18:00 AEST (08:00 UTC) to squash-merge patch/minor Dependabot PRs with passing CI; major bumps are skipped for manual review.

## Any extra notes for reviewers to know?

**One-time repo setting required after merge:** enable **Allow auto-merge** under Settings → General → Pull Requests (needed for `gh pr merge --auto`).

During AEDT (Nov–Apr), the merge cron runs at 7pm Sydney time instead of 6pm because GitHub cron is UTC-based.

You can test the merge workflow manually via Actions → Dependabot Monday auto-merge → Run workflow.