### PR TITLE
Add Java Playwright production smoke test with hourly scheduler

### DIFF
--- a/.github/workflows/sportshub_cloud_functions_deploy_ci.yml
+++ b/.github/workflows/sportshub_cloud_functions_deploy_ci.yml
@@ -57,6 +57,7 @@ jobs:
           echo "LOOPS_API_KEY=\"${{ secrets[matrix.env == 'prod' && 'SOCIALSPORTSPROD_LOOPS_API_KEY' || 'SOCIALSPORTSDEV_LOOPS_API_KEY'] }}\"" >> .env
           echo "DEPLOYMENT_ENV=\"${{ matrix.env == 'prod' && 'prod' || 'dev' }}\"" >> .env
           echo "PROJECT_NAME=\"${{ matrix.env == 'prod' && 'socialsportsprod' || 'socialsports-44162' }}\"" >> .env
+          echo "SMOKE_AUTH_TOKEN=\"${{ secrets[matrix.env == 'prod' && 'SOCIALSPORTSPROD_BEARER_TOKEN' || 'SOCIALSPORTSDEV_BEARER_TOKEN'] }}\"" >> .env
 
       # Deploy Java Cloud Run functions in parallel
       # All functions deploy simultaneously using & to run commands in the background in a non-blocking way
@@ -199,6 +200,20 @@ jobs:
           fi
           PIDS+=($!)  # Capture PID of last background process ($!)
 
+          # Deploy smokeE2eEndpoint in background
+          echo "Starting deployment of smokeE2eEndpoint..."
+          (gcloud functions deploy smokeE2eEndpoint \
+            --entry-point com.functions.smoke.controllers.SmokeE2eEndpoint \
+            --runtime java17 \
+            --trigger-http \
+            --allow-unauthenticated \
+            --region australia-southeast1 \
+            --project $PROJECT_ID \
+            --set-env-vars PROJECT_NAME=$PROJECT_ID \
+            --memory 512 \
+            --quiet 2>&1 | sed 's/^/[smokeE2eEndpoint] /') &
+          PIDS+=($!)  # Capture PID of last background process ($!)
+
           # Wait for all background processes to complete and check their exit codes
           echo ""
           echo "Waiting for all deployments to complete..."
@@ -231,6 +246,7 @@ jobs:
         run: |
           bash ./deploySchedulerToGCloud.sh ${{ matrix.env == 'prod' && 'socialsportsprod' || 'socialsports-44162' }} australia-southeast1 ${{ matrix.env == 'prod' && 'https://australia-southeast1-socialsportsprod.cloudfunctions.net/recurringEventsCron' || 'https://australia-southeast1-socialsports-44162.cloudfunctions.net/recurringEventsCron' }}
           bash ./deployCleanupOldFulfilmentSessionSchedulerToGCloud.sh ${{ matrix.env == 'prod' && 'socialsportsprod' || 'socialsports-44162' }} australia-southeast1 ${{ matrix.env == 'prod' && 'https://australia-southeast1-socialsportsprod.cloudfunctions.net/cleanupOldFulfilmentSessionsCron' || 'https://australia-southeast1-socialsports-44162.cloudfunctions.net/cleanupOldFulfilmentSessionsCron' }}
+          bash ./deploySmokeE2eSchedulerToGCloud.sh ${{ matrix.env == 'prod' && 'socialsportsprod' || 'socialsports-44162' }} australia-southeast1 ${{ matrix.env == 'prod' && 'https://australia-southeast1-socialsportsprod.cloudfunctions.net/smokeE2eEndpoint' || 'https://australia-southeast1-socialsports-44162.cloudfunctions.net/smokeE2eEndpoint' }} ${{ secrets[matrix.env == 'prod' && 'SOCIALSPORTSPROD_BEARER_TOKEN' || 'SOCIALSPORTSDEV_BEARER_TOKEN'] }}
 
       - name: Report scheduler deployment status
         if: failure()

--- a/functions/lib/functions/deployFunctionsToGCloud.sh
+++ b/functions/lib/functions/deployFunctionsToGCloud.sh
@@ -8,6 +8,7 @@
 # completeFulfilmentSession
 # globalAppController
 # stripeWebhookEndpoint
+# smokeE2eEndpoint
 
 # Check if the function name is valid and it should be a list of function name and another list of endpoint class name
 
@@ -19,6 +20,7 @@ VALID_FUNCTIONS=(
     "completeFulfilmentSession"
     "globalAppController"
     "stripeWebhookEndpoint"
+    "smokeE2eEndpoint"
 )
 
 VALID_ENDPOINTS=(
@@ -29,6 +31,7 @@ VALID_ENDPOINTS=(
     "com.functions.fulfilment.controllers.CompleteFulfilmentSessionEndpoint"
     "com.functions.global.controllers.GlobalAppController"
     "com.functions.stripe.controllers.StripeWebhookEndpoint"
+    "com.functions.smoke.controllers.SmokeE2eEndpoint"
 )
 
 # Check for exactly 2 arguments

--- a/functions/lib/functions/deploySmokeE2eSchedulerToGCloud.sh
+++ b/functions/lib/functions/deploySmokeE2eSchedulerToGCloud.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+# ./deploySmokeE2eSchedulerToGCloud.sh <project_id> <region> <function_url> <auth_token>
+PROJECT_ID=${1:-socialsports-44162}
+REGION=${2:-australia-southeast1}
+FUNCTION_URL=${3:-"https://australia-southeast1-socialsports-44162.cloudfunctions.net/smokeE2eEndpoint"}
+AUTH_TOKEN=${4:-""}
+
+if [ -z "$AUTH_TOKEN" ]; then
+  echo "Missing AUTH_TOKEN argument."
+  exit 1
+fi
+
+JOB_NAME=smoke-e2e-hourly-job
+
+if gcloud scheduler jobs describe "$JOB_NAME" --location="$REGION" --project "$PROJECT_ID" >/dev/null 2>&1; then
+  echo "Updating existing scheduler job: $JOB_NAME"
+  gcloud scheduler jobs update http "$JOB_NAME" \
+    --schedule="0 * * * *" \
+    --time-zone="Australia/Sydney" \
+    --uri="$FUNCTION_URL" \
+    --http-method=POST \
+    --headers="Authorization=Bearer ${AUTH_TOKEN}" \
+    --project "$PROJECT_ID" \
+    --location="$REGION"
+else
+  echo "Creating scheduler job: $JOB_NAME"
+  gcloud scheduler jobs create http "$JOB_NAME" \
+    --schedule="0 * * * *" \
+    --time-zone="Australia/Sydney" \
+    --uri="$FUNCTION_URL" \
+    --http-method=POST \
+    --headers="Authorization=Bearer ${AUTH_TOKEN}" \
+    --project "$PROJECT_ID" \
+    --location="$REGION"
+fi

--- a/functions/lib/functions/pom.xml
+++ b/functions/lib/functions/pom.xml
@@ -111,6 +111,11 @@
       <artifactId>commons-validator</artifactId>
       <version>1.9.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>playwright</artifactId>
+      <version>1.53.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/functions/lib/functions/src/main/java/com/functions/smoke/controllers/SmokeE2eEndpoint.java
+++ b/functions/lib/functions/src/main/java/com/functions/smoke/controllers/SmokeE2eEndpoint.java
@@ -1,0 +1,71 @@
+package com.functions.smoke.controllers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.functions.global.controllers.AbstractConfiguredHttpFunction;
+import com.functions.global.handlers.Global;
+import com.functions.smoke.models.SmokeRunResponse;
+import com.functions.smoke.services.SmokeE2eService;
+import com.functions.utils.JavaUtils;
+import com.google.cloud.functions.HttpRequest;
+import com.google.cloud.functions.HttpResponse;
+
+public class SmokeE2eEndpoint extends AbstractConfiguredHttpFunction {
+    private static final Logger logger = LoggerFactory.getLogger(SmokeE2eEndpoint.class);
+
+    @Override
+    public void service(HttpRequest request, HttpResponse response) throws Exception {
+        response.appendHeader("Access-Control-Allow-Origin", "*");
+        response.appendHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+        response.appendHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+        response.appendHeader("Access-Control-Max-Age", "3600");
+        response.appendHeader("Content-Type", "application/json; charset=UTF-8");
+
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            response.setStatusCode(204);
+            return;
+        }
+
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            response.setStatusCode(405);
+            response.appendHeader("Allow", "POST");
+            response.getWriter().write("{\"error\":\"Only POST is supported.\"}");
+            return;
+        }
+
+        if (!isAuthorized(request)) {
+            response.setStatusCode(401);
+            response.getWriter().write("{\"error\":\"Unauthorized\"}");
+            return;
+        }
+
+        SmokeRunResponse runResponse = new SmokeE2eService().run();
+        String logPayload = JavaUtils.objectMapper.writeValueAsString(runResponse.toLogMap());
+
+        if ("PASSED".equals(runResponse.status) && "SUCCESS".equals(runResponse.cleanupStatus)) {
+            logger.info("smoke_e2e_run {}", logPayload);
+            response.setStatusCode(200);
+        } else {
+            logger.error("smoke_e2e_run {}", logPayload);
+            response.setStatusCode(500);
+        }
+
+        response.getWriter().write(JavaUtils.objectMapper.writeValueAsString(runResponse));
+    }
+
+    private static boolean isAuthorized(HttpRequest request) {
+        String expectedToken = Global.getEnv("SMOKE_AUTH_TOKEN");
+        if (expectedToken == null || expectedToken.isBlank()) {
+            // Backward compatible fallback to existing bearer token env.
+            expectedToken = Global.getEnv("BEARER_TOKEN");
+        }
+        if (expectedToken == null || expectedToken.isBlank()) {
+            return false;
+        }
+
+        String authHeader = request.getFirstHeader("Authorization").orElse("");
+        String expectedHeader = "Bearer " + expectedToken.trim();
+        return expectedHeader.equals(authHeader.trim());
+    }
+}

--- a/functions/lib/functions/src/main/java/com/functions/smoke/models/SmokeRunResponse.java
+++ b/functions/lib/functions/src/main/java/com/functions/smoke/models/SmokeRunResponse.java
@@ -1,0 +1,30 @@
+package com.functions.smoke.models;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class SmokeRunResponse {
+    public String runId;
+    public String runMarker;
+    public String status;
+    public String failedStep;
+    public long durationMs;
+    public Long homeLoadMs;
+    public String orderId;
+    public String cleanupStatus;
+    public String error;
+
+    public Map<String, Object> toLogMap() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("runId", runId);
+        map.put("runMarker", runMarker);
+        map.put("status", status);
+        map.put("failedStep", failedStep);
+        map.put("durationMs", durationMs);
+        map.put("homeLoadMs", homeLoadMs);
+        map.put("orderId", orderId);
+        map.put("cleanupStatus", cleanupStatus);
+        map.put("error", error);
+        return map;
+    }
+}

--- a/functions/lib/functions/src/main/java/com/functions/smoke/services/SmokeE2eService.java
+++ b/functions/lib/functions/src/main/java/com/functions/smoke/services/SmokeE2eService.java
@@ -1,0 +1,427 @@
+package com.functions.smoke.services;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.functions.events.models.AbstractEventData.AttendeesMetadata;
+import com.functions.events.models.Attendee;
+import com.functions.events.models.EventData;
+import com.functions.events.models.EventMetadata;
+import com.functions.events.models.Purchaser;
+import com.functions.events.repositories.EventsRepository;
+import com.functions.firebase.services.FirebaseService;
+import com.functions.global.handlers.Global;
+import com.functions.smoke.models.SmokeRunResponse;
+import com.functions.tickets.models.Order;
+import com.functions.tickets.models.Ticket;
+import com.functions.tickets.repositories.OrdersRepository;
+import com.functions.tickets.repositories.TicketsRepository;
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.LoadState;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Transaction;
+
+public class SmokeE2eService {
+    private static final Logger logger = LoggerFactory.getLogger(SmokeE2eService.class);
+
+    private static final String DEFAULT_BASE_URL = "https://www.sportshub.net.au";
+    private static final long DEFAULT_HOME_TIMEOUT_MS = 10_000L;
+    private static final long DEFAULT_VERIFY_TIMEOUT_MS = 90_000L;
+    private static final long ORDER_POLL_INTERVAL_MS = 2_000L;
+
+    public SmokeRunResponse run() {
+        Instant startedAt = Instant.now();
+        String runId = UUID.randomUUID().toString();
+        String runMarker = "SMOKE_" + runId;
+
+        SmokeRunResponse response = new SmokeRunResponse();
+        response.runId = runId;
+        response.runMarker = runMarker;
+        response.status = "FAILED";
+        response.cleanupStatus = "NOT_STARTED";
+        response.failedStep = "INIT";
+
+        String baseUrl = getEnvOrDefault("BASE_URL", DEFAULT_BASE_URL);
+        String sentinelEventUrl = resolveSentinelEventUrl(baseUrl);
+        long homeTimeoutMs = getLongEnvOrDefault("HOME_LOAD_TIMEOUT_MS", DEFAULT_HOME_TIMEOUT_MS);
+        long verifyTimeoutMs = getLongEnvOrDefault("ORDER_VERIFY_TIMEOUT_MS", DEFAULT_VERIFY_TIMEOUT_MS);
+        boolean headless = getBooleanEnvOrDefault("PLAYWRIGHT_HEADLESS", true);
+
+        Order locatedOrder = null;
+        String sentinelEventId = extractEventId(sentinelEventUrl);
+
+        try {
+            response.failedStep = "HOME_LOAD";
+            response.homeLoadMs = runBrowserFlowAndMeasureHomeLoad(
+                    baseUrl,
+                    sentinelEventUrl,
+                    runMarker,
+                    runMarker.toLowerCase(Locale.ROOT) + "@smoke.sportshub.invalid",
+                    headless,
+                    homeTimeoutMs);
+
+            response.failedStep = "ORDER_VERIFY";
+            locatedOrder = waitForOrderByRunMarker(runMarker, verifyTimeoutMs);
+            response.orderId = locatedOrder.getOrderId();
+
+            List<Ticket> orderTickets = TicketsRepository.getTicketsByIds(locatedOrder.getTickets());
+            boolean tiedToSentinel = orderTickets.stream().anyMatch(t -> sentinelEventId.equals(t.getEventId()));
+            if (!tiedToSentinel) {
+                throw new IllegalStateException("Order found but not tied to sentinel event. orderId=" + response.orderId);
+            }
+
+            response.status = "PASSED";
+            response.failedStep = "";
+        } catch (Exception e) {
+            response.error = e.getMessage();
+            logger.error("Smoke run failed. runId={}, runMarker={}", runId, runMarker, e);
+        } finally {
+            response.cleanupStatus = cleanupRunArtifacts(runMarker, Optional.ofNullable(locatedOrder));
+            response.durationMs = Duration.between(startedAt, Instant.now()).toMillis();
+        }
+
+        return response;
+    }
+
+    private static Long runBrowserFlowAndMeasureHomeLoad(
+            String baseUrl,
+            String sentinelEventUrl,
+            String runMarker,
+            String email,
+            boolean headless,
+            long homeTimeoutMs) {
+        Instant homeStart = Instant.now();
+
+        try (Playwright playwright = Playwright.create()) {
+            Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(headless));
+            Page page = browser.newPage();
+            page.setDefaultTimeout(15_000);
+            page.setDefaultNavigationTimeout(Math.max(homeTimeoutMs, 15_000));
+
+            page.navigate(baseUrl);
+            page.waitForLoadState(LoadState.NETWORKIDLE);
+            long homeLoadMs = Duration.between(homeStart, Instant.now()).toMillis();
+            if (homeLoadMs > homeTimeoutMs) {
+                throw new IllegalStateException("Home page load exceeded timeout: " + homeLoadMs + "ms > " + homeTimeoutMs + "ms");
+            }
+
+            page.navigate(sentinelEventUrl);
+            page.waitForLoadState(LoadState.DOMCONTENTLOADED);
+            page.getByRole(com.microsoft.playwright.options.AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Book Now"))
+                    .first()
+                    .click();
+
+            fillCheckoutDetails(page, runMarker, email);
+            submitCheckout(page);
+
+            browser.close();
+            return homeLoadMs;
+        }
+    }
+
+    private static void fillCheckoutDetails(Page page, String runMarker, String email) {
+        tryFill(page, List.of(
+                page.getByLabel("Full name"),
+                page.getByLabel("Name"),
+                page.getByPlaceholder("Full name"),
+                page.getByPlaceholder("Name")));
+        tryFillValue(page, runMarker, List.of(
+                page.getByLabel("Full name"),
+                page.getByLabel("Name"),
+                page.getByPlaceholder("Full name"),
+                page.getByPlaceholder("Name")));
+
+        tryFillValue(page, email, List.of(
+                page.getByLabel("Email"),
+                page.getByPlaceholder("Email"),
+                page.locator("input[type='email']")));
+
+        tryFillValue(page, "0400000000", List.of(
+                page.getByLabel("Phone"),
+                page.getByLabel("Phone number"),
+                page.getByPlaceholder("Phone"),
+                page.locator("input[type='tel']")));
+    }
+
+    private static void submitCheckout(Page page) {
+        List<Locator> submitCandidates = List.of(
+                page.getByRole(com.microsoft.playwright.options.AriaRole.BUTTON,
+                        new Page.GetByRoleOptions().setName("Pay")),
+                page.getByRole(com.microsoft.playwright.options.AriaRole.BUTTON,
+                        new Page.GetByRoleOptions().setName("Complete")),
+                page.getByRole(com.microsoft.playwright.options.AriaRole.BUTTON,
+                        new Page.GetByRoleOptions().setName("Book")),
+                page.getByRole(com.microsoft.playwright.options.AriaRole.BUTTON,
+                        new Page.GetByRoleOptions().setName("Submit"))
+        );
+
+        for (Locator candidate : submitCandidates) {
+            if (candidate.count() > 0) {
+                candidate.first().click();
+                return;
+            }
+        }
+        throw new IllegalStateException("Unable to find checkout submit button.");
+    }
+
+    private static void tryFill(Page page, List<Locator> candidates) {
+        for (Locator candidate : candidates) {
+            if (candidate.count() > 0 && candidate.first().isVisible()) {
+                return;
+            }
+        }
+    }
+
+    private static void tryFillValue(Page page, String value, List<Locator> candidates) {
+        for (Locator candidate : candidates) {
+            if (candidate.count() == 0) {
+                continue;
+            }
+            Locator first = candidate.first();
+            if (!first.isVisible()) {
+                continue;
+            }
+            try {
+                first.fill(value);
+                return;
+            } catch (Exception ignored) {
+                // Try the next locator candidate.
+            }
+        }
+    }
+
+    private static Order waitForOrderByRunMarker(String runMarker, long verifyTimeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + verifyTimeoutMs;
+        Order mostRecent = null;
+
+        while (System.currentTimeMillis() < deadline) {
+            Optional<Order> maybeOrder = OrdersRepository.getMostRecentOrderByFullName(runMarker);
+            if (maybeOrder.isPresent()) {
+                mostRecent = maybeOrder.get();
+                break;
+            }
+            TimeUnit.MILLISECONDS.sleep(ORDER_POLL_INTERVAL_MS);
+        }
+
+        if (mostRecent == null) {
+            throw new IllegalStateException("Could not locate order for run marker within timeout: " + runMarker);
+        }
+        return mostRecent;
+    }
+
+    private static String cleanupRunArtifacts(String runMarker, Optional<Order> locatedOrder) {
+        try {
+            Optional<Order> orderToCleanup = locatedOrder.isPresent()
+                    ? locatedOrder
+                    : OrdersRepository.getMostRecentOrderByFullName(runMarker);
+
+            if (orderToCleanup.isEmpty()) {
+                return "SKIPPED_NO_ORDER";
+            }
+
+            hardDeleteOrderAndRelatedData(orderToCleanup.get());
+            return "SUCCESS";
+        } catch (Exception e) {
+            logger.error("Cleanup failed for runMarker={}", runMarker, e);
+            return "FAILED";
+        }
+    }
+
+    private static void hardDeleteOrderAndRelatedData(Order order) throws Exception {
+        FirebaseService.createFirestoreTransaction((Transaction transaction) -> {
+            Optional<Order> latestOrder = OrdersRepository.getOrderById(order.getOrderId(), Optional.of(transaction));
+            if (latestOrder.isEmpty()) {
+                return "already-deleted";
+            }
+
+            Order existingOrder = latestOrder.get();
+            List<Ticket> tickets = TicketsRepository.getTicketsByIds(existingOrder.getTickets(), Optional.of(transaction));
+            if (tickets.isEmpty()) {
+                OrdersRepository.deleteOrderById(existingOrder.getOrderId(), Optional.of(transaction));
+                return "order-only-deleted";
+            }
+
+            String eventId = tickets.get(0).getEventId();
+            DocumentReference eventRef = EventsRepository.getEventDocumentReferenceInTransaction(eventId, transaction);
+            DocumentSnapshot eventSnapshot = transaction.get(eventRef).get();
+            EventData eventData = eventSnapshot.exists() ? eventSnapshot.toObject(EventData.class) : null;
+
+            DocumentReference metadataRef = EventsRepository.getEventMetadataDocumentReference(eventId);
+            DocumentSnapshot metadataSnapshot = transaction.get(metadataRef).get();
+            EventMetadata eventMetadata = metadataSnapshot.exists() ? metadataSnapshot.toObject(EventMetadata.class) : null;
+
+            int ticketCount = tickets.size();
+
+            // Reads complete; start writes.
+            for (Ticket ticket : tickets) {
+                TicketsRepository.deleteTicketById(ticket.getTicketId(), Optional.of(transaction));
+            }
+            OrdersRepository.deleteOrderById(existingOrder.getOrderId(), Optional.of(transaction));
+
+            if (eventData != null) {
+                int currentVacancy = eventData.getVacancy() == null ? 0 : eventData.getVacancy();
+                eventData.setVacancy(currentVacancy + ticketCount);
+
+                Map<String, Integer> attendees = new HashMap<>(
+                        eventData.getAttendees() == null ? Map.of() : eventData.getAttendees());
+                String email = existingOrder.getEmail();
+                if (email != null && attendees.containsKey(email)) {
+                    int next = attendees.get(email) - ticketCount;
+                    if (next <= 0) {
+                        attendees.remove(email);
+                    } else {
+                        attendees.put(email, next);
+                    }
+                }
+                eventData.setAttendees(attendees);
+
+                Map<String, AttendeesMetadata> attendeesMetadata = new HashMap<>(
+                        eventData.getAttendeesMetadata() == null ? Map.of() : eventData.getAttendeesMetadata());
+                if (email != null && attendeesMetadata.containsKey(email)) {
+                    AttendeesMetadata metadata = attendeesMetadata.get(email);
+                    if (metadata != null) {
+                        if (metadata.getNames() != null) {
+                            metadata.getNames().remove(existingOrder.getFullName());
+                        }
+                        if (metadata.getPhones() != null) {
+                            metadata.getPhones().remove(existingOrder.getPhone());
+                        }
+                        boolean namesEmpty = metadata.getNames() == null || metadata.getNames().isEmpty();
+                        boolean phonesEmpty = metadata.getPhones() == null || metadata.getPhones().isEmpty();
+                        if (namesEmpty && phonesEmpty) {
+                            attendeesMetadata.remove(email);
+                        } else {
+                            attendeesMetadata.put(email, metadata);
+                        }
+                    }
+                }
+                eventData.setAttendeesMetadata(attendeesMetadata);
+
+                EventsRepository.updateEventByReference(eventRef, "vacancy", eventData.getVacancy(), transaction);
+                EventsRepository.updateEventByReference(eventRef, "attendees", eventData.getAttendees(), transaction);
+                EventsRepository.updateEventByReference(eventRef, "attendeesMetadata", eventData.getAttendeesMetadata(), transaction);
+            }
+
+            if (eventMetadata != null) {
+                List<String> orderIds = eventMetadata.getOrderIds() == null
+                        ? new ArrayList<>()
+                        : new ArrayList<>(eventMetadata.getOrderIds());
+                orderIds.remove(existingOrder.getOrderId());
+                eventMetadata.setOrderIds(orderIds);
+
+                int completeTicketCount = eventMetadata.getCompleteTicketCount() == null
+                        ? 0
+                        : eventMetadata.getCompleteTicketCount();
+                eventMetadata.setCompleteTicketCount(Math.max(0, completeTicketCount - ticketCount));
+
+                Map<String, Purchaser> purchaserMap = eventMetadata.getPurchaserMap();
+                if (purchaserMap != null && existingOrder.getEmail() != null) {
+                    Purchaser purchaser = purchaserMap.get(existingOrder.getEmail());
+                    if (purchaser != null) {
+                        int purchaserTotal = purchaser.getTotalTicketCount() == null ? 0 : purchaser.getTotalTicketCount();
+                        purchaser.setTotalTicketCount(Math.max(0, purchaserTotal - ticketCount));
+
+                        Map<String, Attendee> purchaserAttendees = purchaser.getAttendees();
+                        if (purchaserAttendees != null && existingOrder.getFullName() != null) {
+                            Attendee attendee = purchaserAttendees.get(existingOrder.getFullName());
+                            if (attendee != null) {
+                                int current = attendee.getTicketCount() == null ? 0 : attendee.getTicketCount();
+                                int next = current - ticketCount;
+                                if (next <= 0) {
+                                    purchaserAttendees.remove(existingOrder.getFullName());
+                                } else {
+                                    attendee.setTicketCount(next);
+                                    purchaserAttendees.put(existingOrder.getFullName(), attendee);
+                                }
+                            }
+                            if (purchaserAttendees.isEmpty()) {
+                                purchaserMap.remove(existingOrder.getEmail());
+                            } else {
+                                purchaser.setAttendees(purchaserAttendees);
+                                purchaserMap.put(existingOrder.getEmail(), purchaser);
+                            }
+                        }
+                    }
+                    eventMetadata.setPurchaserMap(purchaserMap);
+                }
+
+                EventsRepository.updateEventMetadataByReference(metadataRef, eventMetadata, transaction);
+            }
+
+            return "deleted";
+        });
+    }
+
+    private static String resolveSentinelEventUrl(String baseUrl) {
+        String explicitUrl = Global.getEnv("SENTINEL_EVENT_URL");
+        if (explicitUrl != null && !explicitUrl.isBlank()) {
+            return explicitUrl;
+        }
+
+        String sentinelEventId = Global.getEnv("SENTINEL_EVENT_ID");
+        if (sentinelEventId == null || sentinelEventId.isBlank()) {
+            throw new IllegalArgumentException("Either SENTINEL_EVENT_URL or SENTINEL_EVENT_ID must be set.");
+        }
+
+        String normalizedBase = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        return normalizedBase + "/event/" + sentinelEventId;
+    }
+
+    private static String extractEventId(String sentinelEventUrl) {
+        URI uri = URI.create(sentinelEventUrl);
+        String path = uri.getPath();
+        if (path == null || path.isBlank()) {
+            throw new IllegalArgumentException("Invalid sentinel event URL path: " + sentinelEventUrl);
+        }
+
+        String[] segments = path.split("/");
+        for (int i = 0; i < segments.length; i++) {
+            if ("event".equals(segments[i]) && i + 1 < segments.length && !segments[i + 1].isBlank()) {
+                return segments[i + 1];
+            }
+        }
+        throw new IllegalArgumentException("Could not parse event id from sentinel URL: " + sentinelEventUrl);
+    }
+
+    private static String getEnvOrDefault(String key, String fallback) {
+        String value = Global.getEnv(key);
+        return (value == null || value.isBlank()) ? fallback : value.trim();
+    }
+
+    private static long getLongEnvOrDefault(String key, long fallback) {
+        String value = Global.getEnv(key);
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    private static boolean getBooleanEnvOrDefault(String key, boolean fallback) {
+        String value = Global.getEnv(key);
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        return Boolean.parseBoolean(value.trim());
+    }
+}

--- a/functions/lib/functions/src/main/java/com/functions/tickets/repositories/OrdersRepository.java
+++ b/functions/lib/functions/src/main/java/com/functions/tickets/repositories/OrdersRepository.java
@@ -138,6 +138,35 @@ public class OrdersRepository {
         }
     }
 
+    public static Optional<Order> getMostRecentOrderByFullName(String fullName) {
+        if (fullName == null || fullName.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            Firestore db = FirebaseService.getFirestore();
+            QuerySnapshot querySnapshot = db.collection(ORDERS_COLLECTION)
+                    .whereEqualTo("fullName", fullName)
+                    .orderBy("datePurchased", com.google.cloud.firestore.Query.Direction.DESCENDING)
+                    .limit(1)
+                    .get()
+                    .get();
+
+            if (querySnapshot.isEmpty()) {
+                return Optional.empty();
+            }
+
+            QueryDocumentSnapshot document = querySnapshot.getDocuments().get(0);
+            Order order = document.toObject(Order.class);
+            if (order != null) {
+                order.setOrderId(document.getId());
+            }
+            return Optional.ofNullable(order);
+        } catch (Exception e) {
+            logger.error("Failed to query order by fullName: {}", fullName, e);
+            return Optional.empty();
+        }
+    }
+
     /**
      * Generates a new unique order ID without writing to Firestore.
      */
@@ -182,5 +211,20 @@ public class OrdersRepository {
         transaction.update(metadataRef, "orderIds", FieldValue.arrayUnion(orderId));
 
         return orderId;
+    }
+
+    public static void deleteOrderById(String orderId, Optional<Transaction> transaction) {
+        try {
+            Firestore db = FirebaseService.getFirestore();
+            DocumentReference docRef = db.collection(ORDERS_COLLECTION).document(orderId);
+            if (transaction.isPresent()) {
+                transaction.get().delete(docRef);
+            } else {
+                docRef.delete().get();
+            }
+        } catch (Exception e) {
+            logger.error("Failed to delete order: {}", orderId, e);
+            throw new RuntimeException("Failed to delete order", e);
+        }
     }
 }

--- a/functions/lib/functions/src/main/java/com/functions/tickets/repositories/TicketsRepository.java
+++ b/functions/lib/functions/src/main/java/com/functions/tickets/repositories/TicketsRepository.java
@@ -133,4 +133,19 @@ public class TicketsRepository {
             return new ArrayList<>();
         }
     }
+
+    public static void deleteTicketById(String ticketId, Optional<Transaction> transaction) {
+        try {
+            Firestore db = FirebaseService.getFirestore();
+            DocumentReference docRef = db.collection(TICKETS_COLLECTION).document(ticketId);
+            if (transaction.isPresent()) {
+                transaction.get().delete(docRef);
+            } else {
+                docRef.delete().get();
+            }
+        } catch (Exception e) {
+            logger.error("Failed to delete ticket: {}", ticketId, e);
+            throw new RuntimeException("Failed to delete ticket", e);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a new Java Cloud Function endpoint `smokeE2eEndpoint` (`POST /smoke/run`) to run a production smoke test
- implement Playwright Java booking flow using a Stripe `fullName` run marker (`SMOKE_<uuid>`)
- verify booking success by querying Firestore `Orders` via the run marker
- perform hard cleanup of smoke artifacts (tickets/order/event metadata updates) in a transactional cleanup pass
- add deployment and scheduler wiring for hourly execution (`0 * * * *`) with bearer auth

## Key Details
- New smoke components:
  - `SmokeE2eEndpoint`
  - `SmokeE2eService`
  - `SmokeRunResponse`
- Firestore repo enhancements:
  - `OrdersRepository.getMostRecentOrderByFullName(...)`
  - `OrdersRepository.deleteOrderById(...)`
  - `TicketsRepository.deleteTicketById(...)`
- Deployment updates:
  - add Playwright Java dependency in Maven
  - add `deploySmokeE2eSchedulerToGCloud.sh`
  - update Java function deployment workflow and scripts to deploy/schedule smoke endpoint

## Config
- `BASE_URL`
- `SENTINEL_EVENT_URL` or `SENTINEL_EVENT_ID`
- `HOME_LOAD_TIMEOUT_MS`
- `ORDER_VERIFY_TIMEOUT_MS`
- `SMOKE_AUTH_TOKEN` (fallback `BEARER_TOKEN`)
- optional `PLAYWRIGHT_HEADLESS`

## Validation
- `cd functions/lib/functions && mvn -q -DskipTests compile`

## Notes
- first live run may need minor selector tuning depending on Stripe checkout DOM changes
- logs are emitted as structured JSON-style payloads for `INFO`/`ERROR` paths